### PR TITLE
data-source: oxide-image acceptance tests

### DIFF
--- a/component/data-source/image/data_source_test.go
+++ b/component/data-source/image/data_source_test.go
@@ -1,0 +1,357 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package image_test
+
+import (
+	"embed"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/hashicorp/packer-plugin-sdk/acctest"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+//go:embed testdata/*.pkr.hcl.tmpl
+var packerTemplates embed.FS
+
+// TestAccDataSource_Config tests that the oxide-image data source fails when
+// required configuration attributes are not provided.
+func TestAccDataSource_Config(t *testing.T) {
+	requiredEnvVars := []string{"OXIDE_HOST", "OXIDE_TOKEN"}
+	for _, envVar := range requiredEnvVars {
+		if os.Getenv(envVar) == "" {
+			t.Fatalf("%s environment variable is required", envVar)
+		}
+	}
+
+	tmpl := template.Must(template.ParseFS(packerTemplates, "testdata/*.pkr.hcl.tmpl"))
+
+	// executeTemplate is a helper function that renders a Go template and returns
+	// the rendered template to the caller, failing the test when the template
+	// cannot be rendered. This helps assign a Packer template to the Template
+	// field in test cases. Tests should probably use [fmt.Sprintf] to build
+	// Packer templates instead of Go templates but it's an interesting experiment
+	// to try and use Go templates.
+	executeTemplate := func(t *testing.T, name string, data any) string {
+		var s strings.Builder
+		if err := tmpl.ExecuteTemplate(&s, name, data); err != nil {
+			t.Fatalf("failed executing template %s: %v", name, err)
+		}
+		return s.String()
+	}
+
+	// Hold on to these so we can reset their values in between tests.
+	oxideHost := os.Getenv("OXIDE_HOST")
+	oxideToken := os.Getenv("OXIDE_TOKEN")
+
+	tt := []*acctest.PluginTestCase{
+		{
+			Name: "MissingAllRequiredFields",
+			Type: "oxide-image",
+			Template: executeTemplate(
+				t,
+				"config.pkr.hcl.tmpl",
+				struct{ Name string }{Name: ""},
+			),
+			Check: func(buildCommand *exec.Cmd, logfile string) error {
+				if buildCommand.ProcessState != nil {
+					if buildCommand.ProcessState.ExitCode() != 1 {
+						return fmt.Errorf("Unexpected exit code. Logfile: %s", logfile)
+					}
+				}
+
+				assertFileContains(t, logfile, "host is required")
+				assertFileContains(t, logfile, "token is required")
+				assertFileContains(t, logfile, "name is required")
+
+				return nil
+			},
+			Setup: func() error {
+				os.Unsetenv("OXIDE_HOST")
+				os.Unsetenv("OXIDE_TOKEN")
+				return nil
+			},
+			Teardown: func() error {
+				os.Setenv("OXIDE_HOST", oxideHost)
+				os.Setenv("OXIDE_TOKEN", oxideToken)
+				return nil
+			},
+		},
+		{
+			Name: "MissingAPICredentials",
+			Type: "oxide-image",
+			Template: executeTemplate(
+				t,
+				"config.pkr.hcl.tmpl",
+				struct{ Name string }{Name: "test-image"},
+			),
+			Check: func(buildCommand *exec.Cmd, logfile string) error {
+				if buildCommand.ProcessState != nil {
+					if buildCommand.ProcessState.ExitCode() != 1 {
+						return fmt.Errorf("Unexpected exit code. Logfile: %s", logfile)
+					}
+				}
+
+				assertFileContains(t, logfile, "host is required")
+				assertFileContains(t, logfile, "token is required")
+
+				return nil
+			},
+			Setup: func() error {
+				os.Unsetenv("OXIDE_HOST")
+				os.Unsetenv("OXIDE_TOKEN")
+				return nil
+			},
+			Teardown: func() error {
+				os.Setenv("OXIDE_HOST", oxideHost)
+				os.Setenv("OXIDE_TOKEN", oxideToken)
+				return nil
+			},
+		},
+		{
+			Name: "MissingName",
+			Type: "oxide-image",
+			Template: executeTemplate(
+				t,
+				"config.pkr.hcl.tmpl",
+				struct{ Name string }{Name: ""},
+			),
+			Check: func(buildCommand *exec.Cmd, logfile string) error {
+				if buildCommand.ProcessState != nil {
+					if buildCommand.ProcessState.ExitCode() != 1 {
+						return fmt.Errorf("Unexpected exit code. Logfile: %s", logfile)
+					}
+				}
+
+				assertFileContains(t, logfile, "name is required")
+
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			acctest.TestPlugin(t, tc)
+		})
+	}
+}
+
+// TestAccDataSource_Image tests that the oxide-image data source can
+// successfully read a project image and a silo image from the Oxide API. It
+// makes use of the Setup and Teardown fields within [acctest.PluginTestCase] to
+// create the required image in Oxide before running Packer to retreive it.
+//
+// There's no requirement to use the Setup and Teardown fields within
+// [acctest.PluginTestCase]. In fact, many Packer plugins don't use those fields
+// and instead use custom setup logic within the test and [testing#T.Cleanup]
+// for teardown logic. However, the implementation of this test was a good
+// change to experiment with the APIs provided by [acctest.PluginTestCase] to
+// see how they work.
+func TestAccDataSource_Image(t *testing.T) {
+	requiredEnvVars := []string{"OXIDE_HOST", "OXIDE_TOKEN", "OXIDE_PROJECT"}
+	for _, envVar := range requiredEnvVars {
+		if os.Getenv(envVar) == "" {
+			t.Fatalf("%s environment variable is required", envVar)
+		}
+	}
+
+	tmpl := template.Must(template.ParseFS(packerTemplates, "testdata/*.pkr.hcl.tmpl"))
+
+	oxideClient, err := oxide.NewClient(nil)
+	if err != nil {
+		t.Fatalf("failed creating oxide client: %v", err)
+	}
+
+	oxideProject := os.Getenv("OXIDE_PROJECT")
+
+	tt := []struct {
+		testName  string
+		project   string
+		siloImage bool
+	}{
+		{
+			testName: "ProjectImage",
+			project:  oxideProject,
+		},
+		{
+			testName:  "SiloImage",
+			project:   oxideProject,
+			siloImage: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.testName, func(t *testing.T) {
+			// This test ID must be unique between tests to ensure there's no naming
+			// conflict when creating resources in Oxide. Having a unique, but known,
+			// test ID allows the test to create and destroy disks, snapshots, and
+			// images within the Setup and Teardown fields without creating some other
+			// mechanism to share state.
+			testID := fmt.Sprintf("packer-%d", time.Now().UnixNano())
+
+			diskName := fmt.Sprintf("%s-%s", testID, "disk")
+			snapshotName := fmt.Sprintf("%s-%s", testID, "snapshot")
+			imageName := fmt.Sprintf("%s-%s", testID, "image")
+
+			var packerTemplate strings.Builder
+			if err := tmpl.ExecuteTemplate(&packerTemplate, "image.pkr.hcl.tmpl", struct {
+				Name      string
+				Project   string
+				SiloImage bool
+			}{
+				Name:      imageName,
+				Project:   tc.project,
+				SiloImage: tc.siloImage,
+			}); err != nil {
+				t.Fatalf("failed rendering packer template: %v", err)
+			}
+
+			acctest.TestPlugin(t, &acctest.PluginTestCase{
+				Name:     tc.testName,
+				Type:     "oxide-image",
+				Template: packerTemplate.String(),
+				Setup: func() error {
+					t.Logf("setup: creating oxide disk %s", diskName)
+					disk, err := oxideClient.DiskCreate(t.Context(), oxide.DiskCreateParams{
+						Project: oxide.NameOrId(tc.project),
+						Body: &oxide.DiskCreate{
+							Name:        oxide.Name(diskName),
+							Description: fmt.Sprintf("Packer acceptance test %s.", testID),
+							DiskSource: oxide.DiskSource{
+								BlockSize: 4096,
+								Type:      oxide.DiskSourceTypeBlank,
+							},
+							Size: 1024 * 1024 * 1024, // 1 GiB.
+						},
+					})
+					if err != nil {
+						return fmt.Errorf("failed creating disk %s: %v", diskName, err)
+					}
+
+					t.Logf("setup: creating oxide snapshot %s", snapshotName)
+					snapshot, err := oxideClient.SnapshotCreate(t.Context(), oxide.SnapshotCreateParams{
+						Project: oxide.NameOrId(tc.project),
+						Body: &oxide.SnapshotCreate{
+							Name:        oxide.Name(snapshotName),
+							Description: fmt.Sprintf("Packer acceptance test %s.", testID),
+							Disk:        oxide.NameOrId(disk.Id),
+						},
+					})
+					if err != nil {
+						return fmt.Errorf("failed creating snapshot %s: %v", snapshotName, err)
+					}
+
+					t.Logf("setup: creating oxide image %s", imageName)
+					_, err = oxideClient.ImageCreate(t.Context(), oxide.ImageCreateParams{
+						Project: oxide.NameOrId(tc.project),
+						Body: &oxide.ImageCreate{
+							Name:        oxide.Name(imageName),
+							Description: fmt.Sprintf("Packer acceptance test %s.", testID),
+							Os:          "Blank",
+							Version:     "0.0.0",
+							Source: oxide.ImageSource{
+								Id:   snapshot.Id,
+								Type: oxide.ImageSourceTypeSnapshot,
+							},
+						},
+					})
+					if err != nil {
+						return fmt.Errorf("failed creating image %s: %v", imageName, err)
+					}
+
+					if tc.siloImage {
+						t.Logf("setup: promoting oxide image %s", imageName)
+						if _, err := oxideClient.ImagePromote(t.Context(), oxide.ImagePromoteParams{
+							Image:   oxide.NameOrId(imageName),
+							Project: oxide.NameOrId(oxideProject),
+						}); err != nil {
+							return fmt.Errorf("failed promoting oxide image %s: %v", imageName, err)
+						}
+					}
+
+					return nil
+				},
+				Teardown: func() error {
+					var joinedError error
+
+					if tc.siloImage {
+						t.Logf("teardown: demoting oxide image %s", imageName)
+						if _, err := oxideClient.ImageDemote(t.Context(), oxide.ImageDemoteParams{
+							Image:   oxide.NameOrId(imageName),
+							Project: oxide.NameOrId(oxideProject),
+						}); err != nil {
+							joinedError = errors.Join(joinedError, fmt.Errorf("failed demoting oxide image %s: %v", imageName, err))
+						}
+					}
+
+					t.Logf("teardown: deleting oxide image %s", imageName)
+					if err := oxideClient.ImageDelete(t.Context(), oxide.ImageDeleteParams{
+						Image:   oxide.NameOrId(imageName),
+						Project: oxide.NameOrId(oxideProject),
+					}); err != nil {
+						joinedError = errors.Join(joinedError, fmt.Errorf("failed deleting oxide image %s: %v", imageName, err))
+					}
+
+					t.Logf("teardown: deleting oxide snapshot %s", snapshotName)
+					if err := oxideClient.SnapshotDelete(t.Context(), oxide.SnapshotDeleteParams{
+						Snapshot: oxide.NameOrId(snapshotName),
+						Project:  oxide.NameOrId(oxideProject),
+					}); err != nil {
+						joinedError = errors.Join(joinedError, fmt.Errorf("failed deleting oxide snapshot %s: %v", snapshotName, err))
+					}
+
+					t.Logf("teardown: deleting oxide disk %s", diskName)
+					if err := oxideClient.DiskDelete(t.Context(), oxide.DiskDeleteParams{
+						Disk:    oxide.NameOrId(diskName),
+						Project: oxide.NameOrId(oxideProject),
+					}); err != nil {
+						joinedError = errors.Join(joinedError, fmt.Errorf("failed deleting oxide disk %s: %v", imageName, err))
+					}
+
+					if joinedError != nil {
+						return fmt.Errorf("failed tearing down resources: %v", joinedError)
+					}
+
+					return nil
+				},
+				Check: func(buildCommand *exec.Cmd, logfile string) error {
+					if buildCommand.ProcessState != nil {
+						if buildCommand.ProcessState.ExitCode() != 0 {
+							return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
+						}
+					}
+
+					return nil
+				},
+			})
+		})
+	}
+}
+
+func assertFileContains(t *testing.T, filename string, expected string) {
+	f, err := os.Open(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	b, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if matched, _ := regexp.MatchString(expected+".*", string(b)); !matched {
+		t.Fatalf("logs doesn't contain expected value %q:\n%s", expected, string(b))
+	}
+}

--- a/component/data-source/image/testdata/config.pkr.hcl.tmpl
+++ b/component/data-source/image/testdata/config.pkr.hcl.tmpl
@@ -1,0 +1,3 @@
+data "oxide-image" "test" {
+  name = "{{ .Name }}"
+}

--- a/component/data-source/image/testdata/image.pkr.hcl.tmpl
+++ b/component/data-source/image/testdata/image.pkr.hcl.tmpl
@@ -1,0 +1,18 @@
+data "oxide-image" "test" {
+  name    = "{{ .Name }}"
+  {{- if not .SiloImage }}
+  project = "{{ .Project }}"
+  {{- end }}
+}
+
+locals {
+  image_id = data.oxide-image.test.image_id
+}
+
+source "null" "test" {
+  communicator = "none"
+}
+
+build {
+  sources = ["sources.null.test"]
+}

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pkg/sftp v1.13.2 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/ugorji/go/codec v1.2.6 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,9 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=


### PR DESCRIPTION
Added acceptance tests for the `oxide-image` data source to test whether the data source can successfully read images from the Oxide API and to test the required configuration for the data source. No CI/CD yet, that'll be addressed in future changes.

```
> PACKER_ACC=1 OXIDE_PROJECT=packer-acc-test go test -v ./... -run TestAccDataSource -count 1
?       github.com/oxidecomputer/packer-plugin-oxide    [no test files]
?       github.com/oxidecomputer/packer-plugin-oxide/component/builder/instance [no test files]
=== RUN   TestAccDataSource_Config
=== RUN   TestAccDataSource_Config/MissingAllRequiredFields
=== RUN   TestAccDataSource_Config/MissingAPICredentials
=== RUN   TestAccDataSource_Config/MissingName
--- PASS: TestAccDataSource_Config (0.80s)
--- PASS: TestAccDataSource_Config/MissingAllRequiredFields (0.25s)
--- PASS: TestAccDataSource_Config/MissingAPICredentials (0.28s)
--- PASS: TestAccDataSource_Config/MissingName (0.27s)
=== RUN   TestAccDataSource_Image
=== RUN   TestAccDataSource_Image/ProjectImage
data_source_test.go:225: setup: creating oxide disk packer-1747623945412915692-disk
data_source_test.go:242: setup: creating oxide snapshot packer-1747623945412915692-snapshot
data_source_test.go:255: setup: creating oxide image packer-1747623945412915692-image
data_source_test.go:298: teardown: deleting oxide image packer-1747623945412915692-image
data_source_test.go:306: teardown: deleting oxide snapshot packer-1747623945412915692-snapshot
data_source_test.go:314: teardown: deleting oxide disk packer-1747623945412915692-disk
=== RUN   TestAccDataSource_Image/SiloImage
data_source_test.go:225: setup: creating oxide disk packer-1747623963800113854-disk
data_source_test.go:242: setup: creating oxide snapshot packer-1747623963800113854-snapshot
data_source_test.go:255: setup: creating oxide image packer-1747623963800113854-image
data_source_test.go:274: setup: promoting oxide image packer-1747623963800113854-image
data_source_test.go:289: teardown: demoting oxide image packer-1747623963800113854-image
data_source_test.go:298: teardown: deleting oxide image packer-1747623963800113854-image
data_source_test.go:306: teardown: deleting oxide snapshot packer-1747623963800113854-snapshot
data_source_test.go:314: teardown: deleting oxide disk packer-1747623963800113854-disk
--- PASS: TestAccDataSource_Image (32.00s)
--- PASS: TestAccDataSource_Image/ProjectImage (18.39s)
--- PASS: TestAccDataSource_Image/SiloImage (13.61s)
PASS
ok      github.com/oxidecomputer/packer-plugin-oxide/component/data-source/image        32.800s
```