### PR TITLE
docs: document plugin

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -1,0 +1,43 @@
+The [Oxide](https://oxide.computer) Packer plugin is a multi-component plugin
+for building Oxide images.
+
+## Installation
+
+To install this plugin, add the following to your Packer configuration and run
+`packer init`.
+
+```hcl
+packer {
+  required_plugins {
+    oxide = {
+      source  = "github.com/oxidecomputer/oxide"
+      version = ">= 1.0.0"
+    }
+  }
+}
+```
+
+Alternatively, use `packer plugins install` to install this plugin.
+
+```sh
+packer plugins install github.com/oxidecomputer/oxide
+```
+
+## Components
+
+### Builders
+
+- [`instance`](/packer/integrations/oxidecomputer/oxide/latest/components/builder/instance) -
+Builds an Oxide image by creating an instance from a specified image,
+provisioning it, and snapshotting its boot disk into an image. The resulting
+image can be used as the source image for new Oxide instances.
+
+### Data Sources
+
+- [`image`](/packer/integrations/oxidecomputer/oxide/latest/components/data-source/image) -
+Fetches the image ID for an Oxide image using its name. The image can be a
+project image or silo image.
+
+<!-- ### Provisioners -->
+
+<!-- ### Post-Processors -->

--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -1,0 +1,98 @@
+Type: `oxide-instance`
+
+<!-- Code generated from the comments of the Builder struct in component/builder/instance/builder.go; DO NOT EDIT MANUALLY -->
+
+This builder creates custom images on Oxide. The builder launches a temporary
+instance, connects to it using its external IP, provisions it, and then
+creates an image from the instance's boot disk. The resulting image can be
+used to launch new instances.
+
+<!-- End of code generated from the comments of the Builder struct in component/builder/instance/builder.go; -->
+
+
+## Configuration
+
+<!-- Code generated from the comments of the Config struct in component/builder/instance/config.go; DO NOT EDIT MANUALLY -->
+
+The configuration arguments for this builder component. Arguments can
+either be required or optional.
+
+<!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->
+
+
+### Required
+
+<!-- Code generated from the comments of the Config struct in component/builder/instance/config.go; DO NOT EDIT MANUALLY -->
+
+- `host` (string) - Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified, this
+  defaults to the value of the `OXIDE_HOST` environment variable.
+
+- `token` (string) - Oxide API token. If not specified, this defaults to the value of the
+  `OXIDE_TOKEN` environment variable.
+
+- `boot_disk_image_id` (string) - Image ID to use for the instance's boot disk. This can be obtained from the
+  `oxide-image` data source.
+
+- `project` (string) - Name or ID of the project where the temporary instance and resulting image
+  will be created.
+
+<!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->
+
+
+### Optional
+
+<!-- Code generated from the comments of the Config struct in component/builder/instance/config.go; DO NOT EDIT MANUALLY -->
+
+- `boot_disk_size` (uint64) - Size of the boot disk in bytes. Defaults to `21474836480`, or 20 GiB.
+
+- `ip_pool` (string) - IP pool to allocate the instance's external IP from. If not specified, the
+  silo's default IP pool will be used.
+
+- `vpc` (string) - VPC to create the instance within. Defaults to `default`.
+
+- `subnet` (string) - Subnet to create the instance within. Defaults to `default`.
+
+- `name` (string) - Name of the temporary instance. Defaults to `packer-{{timestamp}}`.
+
+- `hostname` (string) - Hostname of the temporary instance. Defaults to `packer-{{timestamp}}`.
+
+- `cpus` (uint64) - Number of vCPUs to provision the instance with. Defaults to `1`.
+
+- `memory` (uint64) - Amount of memory to provision the instance with, in bytes. Defaults to
+  `2147483648`, or 2 GiB.
+
+- `ssh_public_keys` ([]string) - An array of names or IDs of SSH public keys to inject into the instance.
+
+- `artifact_name` (string) - Name of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
+
+<!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->
+
+
+## Examples
+
+Basic build using environment variables for Oxide credentials.
+
+```hcl
+source "oxide-instance" "example" {
+  project            = "oxide"
+  boot_disk_image_id = "feb2c8ee-5a1d-4d66-beeb-289b860561bf"
+
+  ssh_public_keys = [
+    "529885a0-2919-463a-a588-ac48f100a165",
+  ]
+
+  ssh_username   = "ubuntu"
+}
+
+build {
+  sources = [
+    "source.oxide-instance.example",
+  ]
+
+  provisioner "shell" {
+    inline = [
+      "echo 'Hello from Packer!'",
+    ]
+  }
+}
+```

--- a/.web-docs/components/data-source/image/README.md
+++ b/.web-docs/components/data-source/image/README.md
@@ -1,0 +1,72 @@
+Type: `oxide-image`
+
+<!-- Code generated from the comments of the Datasource struct in component/data-source/image/data_source.go; DO NOT EDIT MANUALLY -->
+
+The Oxide `image` data source fetches the image ID for an Oxide image using
+its name. The image can be a project image or silo image.
+
+<!-- End of code generated from the comments of the Datasource struct in component/data-source/image/data_source.go; -->
+
+
+## Configuration
+
+<!-- Code generated from the comments of the Config struct in component/data-source/image/config.go; DO NOT EDIT MANUALLY -->
+
+The configuration arguments for this data source component. Arguments can
+either be required or optional.
+
+<!-- End of code generated from the comments of the Config struct in component/data-source/image/config.go; -->
+
+
+### Required
+
+<!-- Code generated from the comments of the Config struct in component/data-source/image/config.go; DO NOT EDIT MANUALLY -->
+
+- `host` (string) - Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified, this
+  defaults to the value of the `OXIDE_HOST` environment variable.
+
+- `token` (string) - Oxide API token. If not specified, this defaults to the value of the
+  `OXIDE_TOKEN` environment variable.
+
+- `name` (string) - Name of the image to fetch.
+
+<!-- End of code generated from the comments of the Config struct in component/data-source/image/config.go; -->
+
+
+### Optional
+
+<!-- Code generated from the comments of the Config struct in component/data-source/image/config.go; DO NOT EDIT MANUALLY -->
+
+- `project` (string) - Name or ID of the project containing the image to fetch. Leave blank to fetch
+  a silo image instead of a project image.
+
+<!-- End of code generated from the comments of the Config struct in component/data-source/image/config.go; -->
+
+
+## Outputs
+
+<!-- Code generated from the comments of the DatasourceOutput struct in component/data-source/image/output.go; DO NOT EDIT MANUALLY -->
+
+- `image_id` (string) - ID of the image that was fetched.
+
+<!-- End of code generated from the comments of the DatasourceOutput struct in component/data-source/image/output.go; -->
+
+
+## Examples
+
+Fetch a project image.
+
+```hcl
+data "oxide-image" "example" {
+  name    = "ubuntu"
+  project = "oxide"
+}
+```
+
+Fetch a silo image.
+
+```hcl
+data "oxide-image" "example" {
+  name = "ubuntu"
+}
+```

--- a/.web-docs/scripts/compile-to-webdocs.sh
+++ b/.web-docs/scripts/compile-to-webdocs.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+# Converts the folder name that the component documentation file is stored in
+# into the integration slug of the component.
+componentTypeFromFolderName() {
+    if [[ "$1" = "builders" ]]; then
+        echo "builder"
+    elif [[ "$1" = "provisioners" ]]; then
+        echo "provisioner"
+    elif [[ "$1" = "post-processors" ]]; then
+        echo "post-processor"
+    elif [[ "$1" = "datasources" ]]; then
+        echo "data-source"
+    else
+        echo ""
+    fi
+}
+
+# $1: The content to adjust links.
+# $2: The organization of the integration.
+rewriteLinks() {
+  local result="$1"
+  local organization="$2"
+
+  urlSegment="([^/]+)"
+  urlAnchor="(#[^/]+)"
+
+  # Rewrite Component Index Page links to the Integration root page.
+  #
+  #                    (\1)     (\2)      (\3)
+  # /packer/plugins/datasources/amazon#anchor-tag-->
+  # /packer/integrations/hashicorp/amazon#anchor-tag
+  local find="\(\/packer\/plugins\/$urlSegment\/$urlSegment$urlAnchor?\)"
+  local replace="\(\/packer\/integrations\/$organization\/\2\3\)"
+  result="$(echo "$result" | sed -E "s/$find/$replace/g")"
+
+
+  # Rewrite Component links to the Integration component page
+  #
+  #                    (\1)      (\2)       (\3)       (\4)
+  # /packer/plugins/datasources/amazon/parameterstore#anchor-tag -->
+  # /packer/integrations/{organization}/amazon/latest/components/datasources/parameterstore
+  local find="\(\/packer\/plugins\/$urlSegment\/$urlSegment\/$urlSegment$urlAnchor?\)"
+  local replace="\(\/packer\/integrations\/$organization\/\2\/latest\/components\/\1\/\3\4\)"
+  result="$(echo "$result" | sed -E "s/$find/$replace/g")"
+
+  # Rewrite the Component URL segment from the Packer Plugin format
+  # to the Integrations format
+  result="$(echo "$result" \
+      | sed "s/\/datasources\//\/data-source\//g" \
+      | sed "s/\/builders\//\/builder\//g" \
+      | sed "s/\/post-processors\//\/post-processor\//g" \
+      | sed "s/\/provisioners\//\/provisioner\//g" \
+  )"
+
+  echo "$result"
+}
+
+# $1: Docs Dir
+# $2: Web Docs Dir
+# $3: Component File
+# $4: The org of the integration
+processComponentFile() {
+    local docsDir="$1"
+    local webDocsDir="$2"
+    local componentFile="$3"
+
+    local escapedDocsDir="$(echo "$docsDir" | sed 's/\//\\\//g' | sed 's/\./\\\./g')"
+    local componentTypeAndSlug="$(echo "$componentFile" | sed "s/$escapedDocsDir\///g" | sed 's/\.mdx//g')"
+
+    # Parse out the Component Slug & Component Type
+    local componentSlug="$(echo "$componentTypeAndSlug" | cut -d'/' -f 2)"
+    local componentType="$(componentTypeFromFolderName "$(echo "$componentTypeAndSlug" | cut -d'/' -f 1)")"
+    if [[ "$componentType" = "" ]]; then
+        echo "Failed to process '$componentFile', unexpected folder name."
+        echo "Documentation for components must be stored in one of:"
+        echo "builders, provisioners, post-processors, datasources"
+        exit 1
+    fi
+
+
+    # Calculate the location of where this file will ultimately go
+    local webDocsFolder="$webDocsDir/components/$componentType/$componentSlug"
+    mkdir -p "$webDocsFolder"
+    local webDocsFile="$webDocsFolder/README.md"
+    local webDocsFileTmp="$webDocsFolder/README.md.tmp"
+
+    # Copy over the file to its webDocsFile location
+    cp "$componentFile" "$webDocsFile"
+
+    # Remove the Header
+    local lastMetadataLine="$(grep -n -m 2 '^---' "$componentFile" | tail -n1 | cut -d':' -f1)"
+    cat "$webDocsFile" | tail -n +"$(($lastMetadataLine+2))"  > "$webDocsFileTmp"
+    mv "$webDocsFileTmp" "$webDocsFile"
+
+    # Remove the top H1, as this will be added automatically on the web
+    cat "$webDocsFile" | tail -n +3 > "$webDocsFileTmp"
+    mv "$webDocsFileTmp" "$webDocsFile"
+
+    # Rewrite Links
+    rewriteLinks "$(cat "$webDocsFile")" "$4" > "$webDocsFileTmp"
+    mv "$webDocsFileTmp" "$webDocsFile"
+}
+
+# Compiles the Packer SDC compiled docs folder down
+# to a integrations-compliant folder (web docs)
+#
+# $1: The directory of the plugin
+# $2: The directory of the SDC compiled docs files
+# $3: The output directory to place the web-docs files
+# $4: The org of the integration
+compileWebDocs() {
+  local docsDir="$1/$2"
+  local webDocsDir="$1/$3"
+
+  echo "Compiling MDX docs in '$2' to Markdown in '$3'..."
+  # Create the web-docs directory if it hasn't already been created
+  mkdir -p "$webDocsDir"
+
+  # Copy the README over
+  cp "$docsDir/README.md" "$webDocsDir/README.md"
+
+  # Process all MDX component files (exclude index files, which are unsupported)
+  for file in $(find "$docsDir" | grep "$docsDir/.*/.*\.mdx" | grep --invert-match "index.mdx"); do
+    processComponentFile "$docsDir" "$webDocsDir" "$file" "$4"
+  done
+}
+
+compileWebDocs "$1" "$2" "$3" "$4"

--- a/component/builder/instance/artifact.go
+++ b/component/builder/instance/artifact.go
@@ -8,10 +8,14 @@ import "github.com/hashicorp/packer-plugin-sdk/packer"
 
 var _ packer.Artifact = (*Artifact)(nil)
 
-// Artifact is the result of this builder.
+// Artifact represents the Oxide image created by the builder. This artifact
+// contains the image ID and name that can be used to launch new instances.
 type Artifact struct {
-	ImageID   string
+	// Unique identifier of the created image.
+	ImageID string
+	// Name of the created image.
 	ImageName string
+	// Additional state data associated with the build.
 	StateData map[string]any
 }
 
@@ -30,7 +34,7 @@ func (a *Artifact) Id() string {
 	return a.ImageID
 }
 
-// String returns a description to describe the artifact.
+// String returns a description of the artifact.
 func (a *Artifact) String() string {
 	return a.ImageName
 }

--- a/component/builder/instance/builder.go
+++ b/component/builder/instance/builder.go
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//go:generate packer-sdc struct-markdown
+
 package instance
 
 import (
@@ -18,7 +20,10 @@ import (
 
 var _ packer.Builder = (*Builder)(nil)
 
-// Builder is an implementation of [packer.Builder] for use with Oxide.
+// This builder creates custom images on Oxide. The builder launches a temporary
+// instance, connects to it using its external IP, provisions it, and then
+// creates an image from the instance's boot disk. The resulting image can be
+// used to launch new instances.
 type Builder struct {
 	config Config
 	runner multistep.Runner

--- a/component/builder/instance/config.go
+++ b/component/builder/instance/config.go
@@ -3,11 +3,11 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //go:generate packer-sdc mapstructure-to-hcl2 -type Config
+//go:generate packer-sdc struct-markdown
 
 package instance
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -19,54 +19,61 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-// Config represents the Packer configuration for this builder component.
+// The configuration arguments for this builder component. Arguments can
+// either be required or optional.
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
-	// Packer communicator configuration to allow users to configure how Packer will
-	// communicate with an instance.
+	// Packer communicator configuration to configure how Packer connects to the
+    // instance for provisioning.
 	Comm communicator.Config `mapstructure:",squash"`
 
-	// Oxide API address (e.g., https://oxide.sys.example.com).
-	Host string `mapstructure:"host"`
+	// Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified, this
+	// defaults to the value of the `OXIDE_HOST` environment variable.
+	Host string `mapstructure:"host" required:"true"`
 
-	// Oxide API token.
-	Token string `mapstructure:"token"`
+	// Oxide API token. If not specified, this defaults to the value of the
+	// `OXIDE_TOKEN` environment variable.
+	Token string `mapstructure:"token" required:"true"`
 
-	// Image ID to boot the instance from.
-	BootDiskImageID string `mapstructure:"boot_disk_image_id"`
+	// Image ID to use for the instance's boot disk. This can be obtained from the
+	// `oxide-image` data source.
+	BootDiskImageID string `mapstructure:"boot_disk_image_id" required:"true"`
 
-	// Name or ID of the project where the instance will be created.
-	Project string `mapstructure:"project"`
+	// Name or ID of the project where the temporary instance and resulting image
+	// will be created.
+	Project string `mapstructure:"project" required:"true"`
 
-	// Size of the boot disk, in bytes.
+	// Size of the boot disk in bytes. Defaults to `21474836480`, or 20 GiB.
 	BootDiskSize uint64 `mapstructure:"boot_disk_size"`
 
-	// IP pool that the instance's external IP should be allocated from.
+	// IP pool to allocate the instance's external IP from. If not specified, the
+	// silo's default IP pool will be used.
 	IPPool string `mapstructure:"ip_pool"`
 
-	// VPC to create the instance within.
+	// VPC to create the instance within. Defaults to `default`.
 	VPC string `mapstructure:"vpc"`
 
-	// Subnet to create the instance within.
+	// Subnet to create the instance within. Defaults to `default`.
 	Subnet string `mapstructure:"subnet"`
 
-	// Instance name.
+	// Name of the temporary instance. Defaults to `packer-{{timestamp}}`.
 	Name string `mapstructure:"name"`
 
-	// Instance hostname.
+	// Hostname of the temporary instance. Defaults to `packer-{{timestamp}}`.
 	Hostname string `mapstructure:"hostname"`
 
-	// Number of vCPUs to provision the instance with.
+	// Number of vCPUs to provision the instance with. Defaults to `1`.
 	CPUs uint64 `mapstructure:"cpus"`
 
-	// Amount of memory to provision the instance with, in bytes.
+	// Amount of memory to provision the instance with, in bytes. Defaults to
+	// `2147483648`, or 2 GiB.
 	Memory uint64 `mapstructure:"memory"`
 
-	// Names or IDs of SSH public keys to inject into the instance.
+	// An array of names or IDs of SSH public keys to inject into the instance.
 	SSHPublicKeys []string `mapstructure:"ssh_public_keys"`
 
-	// TODO: Name this better?
+	// Name of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
 	ArtifactName string `mapstructure:"artifact_name"`
 
 	ctx interpolate.Context
@@ -85,7 +92,7 @@ func (c *Config) Prepare(args ...any) ([]string, error) {
 		return nil, fmt.Errorf("failed decoding configuration: %w", err)
 	}
 
-	// Configure defaults.
+	// Defaults.
 	{
 		if c.Host == "" {
 			c.Host = os.Getenv("OXIDE_HOST")
@@ -143,25 +150,8 @@ func (c *Config) Prepare(args ...any) ([]string, error) {
 		}
 	}
 
-	// Validate required configuration.
 	{
 		var multiErr *packer.MultiError
-
-		if c.Host == "" {
-			multiErr = packer.MultiErrorAppend(multiErr, errors.New("host is required"))
-		}
-
-		if c.Token == "" {
-			multiErr = packer.MultiErrorAppend(multiErr, errors.New("token is required"))
-		}
-
-		if c.Project == "" {
-			multiErr = packer.MultiErrorAppend(multiErr, errors.New("project is required"))
-		}
-
-		if c.BootDiskImageID == "" {
-			multiErr = packer.MultiErrorAppend(multiErr, errors.New("boot_disk_image_id is required"))
-		}
 
 		if errs := c.Comm.Prepare(&c.ctx); len(errs) > 0 {
 			multiErr = packer.MultiErrorAppend(multiErr, errs...)

--- a/component/builder/instance/config.hcl2spec.go
+++ b/component/builder/instance/config.hcl2spec.go
@@ -67,10 +67,10 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
-	Host                      *string           `mapstructure:"host" cty:"host" hcl:"host"`
-	Token                     *string           `mapstructure:"token" cty:"token" hcl:"token"`
-	BootDiskImageID           *string           `mapstructure:"boot_disk_image_id" cty:"boot_disk_image_id" hcl:"boot_disk_image_id"`
-	Project                   *string           `mapstructure:"project" cty:"project" hcl:"project"`
+	Host                      *string           `mapstructure:"host" required:"true" cty:"host" hcl:"host"`
+	Token                     *string           `mapstructure:"token" required:"true" cty:"token" hcl:"token"`
+	BootDiskImageID           *string           `mapstructure:"boot_disk_image_id" required:"true" cty:"boot_disk_image_id" hcl:"boot_disk_image_id"`
+	Project                   *string           `mapstructure:"project" required:"true" cty:"project" hcl:"project"`
 	BootDiskSize              *uint64           `mapstructure:"boot_disk_size" cty:"boot_disk_size" hcl:"boot_disk_size"`
 	IPPool                    *string           `mapstructure:"ip_pool" cty:"ip_pool" hcl:"ip_pool"`
 	VPC                       *string           `mapstructure:"vpc" cty:"vpc" hcl:"vpc"`

--- a/component/data-source/image/config.go
+++ b/component/data-source/image/config.go
@@ -7,16 +7,19 @@
 
 package image
 
-// Config represents the Packer configuration for this data source component.
+// The configuration arguments for this data source component. Arguments can
+// either be required or optional.
 type Config struct {
-	// Oxide API address (e.g., https://oxide.sys.example.com).
-	Host string `mapstructure:"host"`
+	// Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified, this
+	// defaults to the value of the `OXIDE_HOST` environment variable.
+	Host string `mapstructure:"host" required:"true"`
 
-	// Oxide API token.
-	Token string `mapstructure:"token"`
+	// Oxide API token. If not specified, this defaults to the value of the
+	// `OXIDE_TOKEN` environment variable.
+	Token string `mapstructure:"token" required:"true"`
 
 	// Name of the image to fetch.
-	Name string `mapstructure:"name"`
+	Name string `mapstructure:"name" required:"true"`
 
 	// Name or ID of the project containing the image to fetch. Leave blank to fetch
 	// a silo image instead of a project image.

--- a/component/data-source/image/config.hcl2spec.go
+++ b/component/data-source/image/config.hcl2spec.go
@@ -10,9 +10,9 @@ import (
 // FlatConfig is an auto-generated flat version of Config.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatConfig struct {
-	Host    *string `mapstructure:"host" cty:"host" hcl:"host"`
-	Token   *string `mapstructure:"token" cty:"token" hcl:"token"`
-	Name    *string `mapstructure:"name" cty:"name" hcl:"name"`
+	Host    *string `mapstructure:"host" required:"true" cty:"host" hcl:"host"`
+	Token   *string `mapstructure:"token" required:"true" cty:"token" hcl:"token"`
+	Name    *string `mapstructure:"name" required:"true" cty:"name" hcl:"name"`
 	Project *string `mapstructure:"project" cty:"project" hcl:"project"`
 }
 

--- a/component/data-source/image/data_source.go
+++ b/component/data-source/image/data_source.go
@@ -20,24 +20,24 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-var _ packer.Datasource = (*DataSource)(nil)
+var _ packer.Datasource = (*Datasource)(nil)
 
-// DataSource is the concrete type that implements the Packer data source
-// component interface.
-type DataSource struct {
+// This data source fetches the image ID for an Oxide image using its name. The
+// image can be a project image or silo image.
+type Datasource struct {
 	config Config
 }
 
 // ConfigSpec returns the HCL specification that Packer uses to validate and
 // configure this plugin component.
-func (d *DataSource) ConfigSpec() hcldec.ObjectSpec {
+func (d *Datasource) ConfigSpec() hcldec.ObjectSpec {
 	return d.config.FlatMapstructure().HCL2Spec()
 }
 
 // Configure decodes the configuration for this plugin component, checks whether
 // the configuration is valid, and stores any necessary state for future methods
 // to use during execution.
-func (d *DataSource) Configure(args ...any) error {
+func (d *Datasource) Configure(args ...any) error {
 	if err := config.Decode(&d.config, nil, args...); err != nil {
 		return fmt.Errorf("failed decoding configuration: %w", err)
 	}
@@ -79,7 +79,7 @@ func (d *DataSource) Configure(args ...any) error {
 
 // Execute fetches image information from the Oxide API and returns that
 // information in the format specified by [OutputSpec].
-func (d *DataSource) Execute() (cty.Value, error) {
+func (d *Datasource) Execute() (cty.Value, error) {
 	oxideClient, err := oxide.NewClient(&oxide.Config{
 		Host:  d.config.Host,
 		Token: d.config.Token,
@@ -96,7 +96,7 @@ func (d *DataSource) Execute() (cty.Value, error) {
 		return cty.NullVal(cty.EmptyObject), fmt.Errorf("failed fetching image %q within project %q: %w", d.config.Name, d.config.Project, err)
 	}
 
-	output := Output{
+	output := DatasourceOutput{
 		ImageID: image.Id,
 	}
 
@@ -105,6 +105,6 @@ func (d *DataSource) Execute() (cty.Value, error) {
 
 // OutputSpec returns the HCL specification that Packer uses to populate output
 // values for this plugin component.
-func (d *DataSource) OutputSpec() hcldec.ObjectSpec {
-	return (&Output{}).FlatMapstructure().HCL2Spec()
+func (d *Datasource) OutputSpec() hcldec.ObjectSpec {
+	return (&DatasourceOutput{}).FlatMapstructure().HCL2Spec()
 }

--- a/component/data-source/image/output.go
+++ b/component/data-source/image/output.go
@@ -2,14 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//go:generate packer-sdc mapstructure-to-hcl2 -type Output
+//go:generate packer-sdc mapstructure-to-hcl2 -type DatasourceOutput
 //go:generate packer-sdc struct-markdown
 
 package image
 
-// Output represents the information returned by this plugin component for use
-// in other Packer plugin components.
-type Output struct {
+// The outputs returned by this data source component.
+type DatasourceOutput struct {
 	// ID of the image that was fetched.
 	ImageID string `mapstructure:"image_id"`
 }

--- a/component/data-source/image/output.hcl2spec.go
+++ b/component/data-source/image/output.hcl2spec.go
@@ -7,23 +7,23 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// FlatOutput is an auto-generated flat version of Output.
+// FlatDatasourceOutput is an auto-generated flat version of DatasourceOutput.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
-type FlatOutput struct {
+type FlatDatasourceOutput struct {
 	ImageID *string `mapstructure:"image_id" cty:"image_id" hcl:"image_id"`
 }
 
-// FlatMapstructure returns a new FlatOutput.
-// FlatOutput is an auto-generated flat version of Output.
+// FlatMapstructure returns a new FlatDatasourceOutput.
+// FlatDatasourceOutput is an auto-generated flat version of DatasourceOutput.
 // Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
-func (*Output) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
-	return new(FlatOutput)
+func (*DatasourceOutput) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatDatasourceOutput)
 }
 
-// HCL2Spec returns the hcl spec of a Output.
-// This spec is used by HCL to read the fields of Output.
-// The decoded values from this spec will then be applied to a FlatOutput.
-func (*FlatOutput) HCL2Spec() map[string]hcldec.Spec {
+// HCL2Spec returns the hcl spec of a DatasourceOutput.
+// This spec is used by HCL to read the fields of DatasourceOutput.
+// The decoded values from this spec will then be applied to a FlatDatasourceOutput.
+func (*FlatDatasourceOutput) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"image_id": &hcldec.AttrSpec{Name: "image_id", Type: cty.String, Required: false},
 	}

--- a/docs-partials/component/builder/instance/Builder.mdx
+++ b/docs-partials/component/builder/instance/Builder.mdx
@@ -1,0 +1,8 @@
+<!-- Code generated from the comments of the Builder struct in component/builder/instance/builder.go; DO NOT EDIT MANUALLY -->
+
+This builder creates custom images on Oxide. The builder launches a temporary
+instance, connects to it using its external IP, provisions it, and then
+creates an image from the instance's boot disk. The resulting image can be
+used to launch new instances.
+
+<!-- End of code generated from the comments of the Builder struct in component/builder/instance/builder.go; -->

--- a/docs-partials/component/builder/instance/Config-not-required.mdx
+++ b/docs-partials/component/builder/instance/Config-not-required.mdx
@@ -1,0 +1,25 @@
+<!-- Code generated from the comments of the Config struct in component/builder/instance/config.go; DO NOT EDIT MANUALLY -->
+
+- `boot_disk_size` (uint64) - Size of the boot disk in bytes. Defaults to `21474836480`, or 20 GiB.
+
+- `ip_pool` (string) - IP pool to allocate the instance's external IP from. If not specified, the
+  silo's default IP pool will be used.
+
+- `vpc` (string) - VPC to create the instance within. Defaults to `default`.
+
+- `subnet` (string) - Subnet to create the instance within. Defaults to `default`.
+
+- `name` (string) - Name of the temporary instance. Defaults to `packer-{{timestamp}}`.
+
+- `hostname` (string) - Hostname of the temporary instance. Defaults to `packer-{{timestamp}}`.
+
+- `cpus` (uint64) - Number of vCPUs to provision the instance with. Defaults to `1`.
+
+- `memory` (uint64) - Amount of memory to provision the instance with, in bytes. Defaults to
+  `2147483648`, or 2 GiB.
+
+- `ssh_public_keys` ([]string) - An array of names or IDs of SSH public keys to inject into the instance.
+
+- `artifact_name` (string) - Name of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
+
+<!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->

--- a/docs-partials/component/builder/instance/Config-required.mdx
+++ b/docs-partials/component/builder/instance/Config-required.mdx
@@ -1,0 +1,15 @@
+<!-- Code generated from the comments of the Config struct in component/builder/instance/config.go; DO NOT EDIT MANUALLY -->
+
+- `host` (string) - Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified, this
+  defaults to the value of the `OXIDE_HOST` environment variable.
+
+- `token` (string) - Oxide API token. If not specified, this defaults to the value of the
+  `OXIDE_TOKEN` environment variable.
+
+- `boot_disk_image_id` (string) - Image ID to use for the instance's boot disk. This can be obtained from the
+  `oxide-image` data source.
+
+- `project` (string) - Name or ID of the project where the temporary instance and resulting image
+  will be created.
+
+<!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->

--- a/docs-partials/component/builder/instance/Config.mdx
+++ b/docs-partials/component/builder/instance/Config.mdx
@@ -1,0 +1,6 @@
+<!-- Code generated from the comments of the Config struct in component/builder/instance/config.go; DO NOT EDIT MANUALLY -->
+
+The configuration arguments for this builder component. Arguments can
+either be required or optional.
+
+<!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->

--- a/docs-partials/component/data-source/image/Config-not-required.mdx
+++ b/docs-partials/component/data-source/image/Config-not-required.mdx
@@ -1,11 +1,5 @@
 <!-- Code generated from the comments of the Config struct in component/data-source/image/config.go; DO NOT EDIT MANUALLY -->
 
-- `host` (string) - Oxide API address (e.g., https://oxide.sys.example.com).
-
-- `token` (string) - Oxide API token.
-
-- `name` (string) - Name of the image to fetch.
-
 - `project` (string) - Name or ID of the project containing the image to fetch. Leave blank to fetch
   a silo image instead of a project image.
 

--- a/docs-partials/component/data-source/image/Config-required.mdx
+++ b/docs-partials/component/data-source/image/Config-required.mdx
@@ -1,0 +1,11 @@
+<!-- Code generated from the comments of the Config struct in component/data-source/image/config.go; DO NOT EDIT MANUALLY -->
+
+- `host` (string) - Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified, this
+  defaults to the value of the `OXIDE_HOST` environment variable.
+
+- `token` (string) - Oxide API token. If not specified, this defaults to the value of the
+  `OXIDE_TOKEN` environment variable.
+
+- `name` (string) - Name of the image to fetch.
+
+<!-- End of code generated from the comments of the Config struct in component/data-source/image/config.go; -->

--- a/docs-partials/component/data-source/image/Config.mdx
+++ b/docs-partials/component/data-source/image/Config.mdx
@@ -1,5 +1,6 @@
 <!-- Code generated from the comments of the Config struct in component/data-source/image/config.go; DO NOT EDIT MANUALLY -->
 
-Config represents the Packer configuration for this data source component.
+The configuration arguments for this data source component. Arguments can
+either be required or optional.
 
 <!-- End of code generated from the comments of the Config struct in component/data-source/image/config.go; -->

--- a/docs-partials/component/data-source/image/DataSource.mdx
+++ b/docs-partials/component/data-source/image/DataSource.mdx
@@ -1,6 +1,0 @@
-<!-- Code generated from the comments of the DataSource struct in component/data-source/image/data_source.go; DO NOT EDIT MANUALLY -->
-
-DataSource is the concrete type that implements the Packer data source
-component interface.
-
-<!-- End of code generated from the comments of the DataSource struct in component/data-source/image/data_source.go; -->

--- a/docs-partials/component/data-source/image/Datasource.mdx
+++ b/docs-partials/component/data-source/image/Datasource.mdx
@@ -1,0 +1,6 @@
+<!-- Code generated from the comments of the Datasource struct in component/data-source/image/data_source.go; DO NOT EDIT MANUALLY -->
+
+The Oxide `image` data source fetches the image ID for an Oxide image using
+its name. The image can be a project image or silo image.
+
+<!-- End of code generated from the comments of the Datasource struct in component/data-source/image/data_source.go; -->

--- a/docs-partials/component/data-source/image/DatasourceOutput.mdx
+++ b/docs-partials/component/data-source/image/DatasourceOutput.mdx
@@ -1,0 +1,5 @@
+<!-- Code generated from the comments of the DatasourceOutput struct in component/data-source/image/output.go; DO NOT EDIT MANUALLY -->
+
+- `image_id` (string) - ID of the image that was fetched.
+
+<!-- End of code generated from the comments of the DatasourceOutput struct in component/data-source/image/output.go; -->

--- a/docs-partials/component/data-source/image/Output-not-required.mdx
+++ b/docs-partials/component/data-source/image/Output-not-required.mdx
@@ -1,5 +1,0 @@
-<!-- Code generated from the comments of the Output struct in component/data-source/image/output.go; DO NOT EDIT MANUALLY -->
-
-- `image_id` (string) - ID of the image that was fetched.
-
-<!-- End of code generated from the comments of the Output struct in component/data-source/image/output.go; -->

--- a/docs-partials/component/data-source/image/Output.mdx
+++ b/docs-partials/component/data-source/image/Output.mdx
@@ -1,6 +1,0 @@
-<!-- Code generated from the comments of the Output struct in component/data-source/image/output.go; DO NOT EDIT MANUALLY -->
-
-Output represents the information returned by this plugin component for use
-in other Packer plugin components.
-
-<!-- End of code generated from the comments of the Output struct in component/data-source/image/output.go; -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,44 @@
+The [Oxide](https://oxide.computer) Packer plugin is a multi-component plugin
+for building Oxide images.
+
+## Installation
+
+To install this plugin, add the following to your Packer configuration and run
+`packer init`.
+
+```hcl
+packer {
+  required_plugins {
+    oxide = {
+      source  = "github.com/oxidecomputer/oxide"
+      version = ">= 1.0.0"
+    }
+  }
+}
+```
+
+Alternatively, use `packer plugins install` to install this plugin.
+
+```sh
+packer plugins install github.com/oxidecomputer/oxide
+```
+
+## Components
+
+### Builders
+
+- [`instance`](/packer/integrations/oxidecomputer/oxide/latest/components/builder/instance) -
+This builder creates custom images on Oxide. The builder launches a temporary
+instance, connects to it using its external IP, provisions it, and then
+creates an image from the instance's boot disk. The resulting image can be
+used to launch new instances.
+
+### Data Sources
+
+- [`image`](/packer/integrations/oxidecomputer/oxide/latest/components/data-source/image) -
+This data source fetches the image ID for an Oxide image using its name. The
+image can be a project image or silo image.
+
+<!-- ### Provisioners -->
+
+<!-- ### Post-Processors -->

--- a/docs/builders/instance.mdx
+++ b/docs/builders/instance.mdx
@@ -1,0 +1,56 @@
+---
+description: >
+  This builder creates custom images on Oxide. The builder launches a temporary
+  instance, connects to it using its external IP, provisions it, and then
+  creates an image from the instance's boot disk. The resulting image can be
+  used to launch new instances.
+page_title: Oxide Instance - Builder
+nav_title: oxide-instance
+---
+
+# Oxide Instance - Builder
+
+Type: `oxide-instance`
+
+@include 'component/builder/instance/Builder.mdx'
+
+## Configuration
+
+@include 'component/builder/instance/Config.mdx'
+
+### Required
+
+@include 'component/builder/instance/Config-required.mdx'
+
+### Optional
+
+@include 'component/builder/instance/Config-not-required.mdx'
+
+## Examples
+
+Basic build using environment variables for Oxide credentials.
+
+```hcl
+source "oxide-instance" "example" {
+  project            = "oxide"
+  boot_disk_image_id = "feb2c8ee-5a1d-4d66-beeb-289b860561bf"
+
+  ssh_public_keys = [
+    "529885a0-2919-463a-a588-ac48f100a165",
+  ]
+
+  ssh_username   = "ubuntu"
+}
+
+build {
+  sources = [
+    "source.oxide-instance.example",
+  ]
+
+  provisioner "shell" {
+    inline = [
+      "echo 'Hello from Packer!'",
+    ]
+  }
+}
+```

--- a/docs/datasources/image.mdx
+++ b/docs/datasources/image.mdx
@@ -1,0 +1,48 @@
+---
+description: >
+  Fetches the image ID for an Oxide image using its name. The image can be a
+  project image or silo image.
+page_title: Oxide Image - Data Source
+nav_title: oxide-image
+---
+
+# Oxide Image - Data Source
+
+Type: `oxide-image`
+
+@include 'component/data-source/image/Datasource.mdx'
+
+## Configuration
+
+@include 'component/data-source/image/Config.mdx'
+
+### Required
+
+@include 'component/data-source/image/Config-required.mdx'
+
+### Optional
+
+@include 'component/data-source/image/Config-not-required.mdx'
+
+## Outputs
+
+@include 'component/data-source/image/DatasourceOutput.mdx'
+
+## Examples
+
+Fetch a project image.
+
+```hcl
+data "oxide-image" "example" {
+  name    = "ubuntu"
+  project = "oxide"
+}
+```
+
+Fetch a silo image.
+
+```hcl
+data "oxide-image" "example" {
+  name = "ubuntu"
+}
+```

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ var (
 func main() {
 	pluginSet := plugin.NewSet()
 	pluginSet.RegisterBuilder("instance", new(instance.Builder))
-	pluginSet.RegisterDatasource("image", new(image.DataSource))
+	pluginSet.RegisterDatasource("image", new(image.Datasource))
 	pluginSet.SetVersion(
 		version.NewPluginVersion(Version, VersionPreRelease, VersionMetadata),
 	)


### PR DESCRIPTION
Added the documentation for this plugin using the idioms from github.com/hashicorp/packer-plugin-scaffolding.

Renamed the `image.Output` struct to `image.DatasourceOutput` since the `packer-sdc` command expects the type to be named `DatasourceOutput` per https://github.com/hashicorp/packer-plugin-sdk/blob/7a5a8ab49a63aab6ecd6c54ba71c8e0edb531cf8/cmd/packer-sdc/internal/struct-markdown/struct_markdown.go#L183-L186.