### PR TITLE
builder(instance): ensure instance is stopped before deletion

### DIFF
--- a/component/builder/instance/config.go
+++ b/component/builder/instance/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
 	// Packer communicator configuration to configure how Packer connects to the
-    // instance for provisioning.
+	// instance for provisioning.
 	Comm communicator.Config `mapstructure:",squash"`
 
 	// Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified, this

--- a/component/builder/instance/step_snapshot_create.go
+++ b/component/builder/instance/step_snapshot_create.go
@@ -6,6 +6,7 @@ package instance
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
@@ -64,10 +65,14 @@ func (s *stepSnapshotCreate) Cleanup(stateBag multistep.StateBag) {
 
 		ui.Sayf("Deleting Oxide snapshot: %s", snapshotID)
 
-		if err := oxideClient.SnapshotDelete(context.Background(), oxide.SnapshotDeleteParams{
+		snapshotDeleteCtx, snapshotDeletCtxCancel := context.WithTimeout(context.TODO(), 30*time.Second)
+		defer snapshotDeletCtxCancel()
+
+		if err := oxideClient.SnapshotDelete(snapshotDeleteCtx, oxide.SnapshotDeleteParams{
 			Snapshot: oxide.NameOrId(snapshotID),
 		}); err != nil {
 			ui.Errorf("Failed deleting Oxide snapshot during cleanup. Please delete it manually: %v", err)
+			return
 		}
 	}
 }


### PR DESCRIPTION
Updated `Cleanup` to ensure an instance is stopped before trying to delete it. Previously, if a user interrupted a Packer run right after the instance creation step Packer would crash with the following output.

```
2025/06/19 20:58:52 ui: ==> oxide-instance.example: Deleting Oxide instance: 84e165a9-4b9e-4d16-a8d8-b4bb22c4fd41
2025/06/19 20:58:54 ui error: ==> oxide-instance.example: Failed deleting Oxide instance during cleanup. Please delete it manually: DELETE https://oxide.sys.r3.oxide-preview.com/v1/instances/84e165a9-4b9e-4d16-a8d8-b4bb22c4fd41
==> oxide-instance.example: ----------- RESPONSE -----------
==> oxide-instance.example: Status: 400 InvalidRequest
==> oxide-instance.example: Message: cannot delete instance: instance is running or has not yet fully stopped
==> oxide-instance.example: RequestID: fc20e702-c96a-42c2-acff-5e1e9839721e
==> oxide-instance.example: ------- RESPONSE HEADERS -------
==> oxide-instance.example: Content-Type: [application/json]
==> oxide-instance.example: X-Request-Id: [fc20e702-c96a-42c2-acff-5e1e9839721e]
==> oxide-instance.example: Date: [Fri, 20 Jun 2025 00:58:50 GMT]
==> oxide-instance.example: Content-Length: [181]

2025/06/19 20:58:54 ui: ==> oxide-instance.example: Deleting Oxide disk: 1141881a-9248-4c66-9110-bde3ffc2b10a[0m
2025/06/19 20:58:54 ui error: ==> oxide-instance.example: Failed deleting Oxide disk during cleanup. Please delete it manually: DELETE https://oxide.sys.r3.oxide-preview.com/v1/disks/1141881a-9248-4c66-9110-bde3ffc2b10a
==> oxide-instance.example: ----------- RESPONSE -----------
==> oxide-instance.example: Status: 400 InvalidRequest
==> oxide-instance.example: Message: disk cannot be deleted in state "attached"
==> oxide-instance.example: RequestID: 27f942c3-82e0-4fa4-bf7a-68c386204296
==> oxide-instance.example: ------- RESPONSE HEADERS -------
==> oxide-instance.example: Content-Type: [application/json]
==> oxide-instance.example: X-Request-Id: [27f942c3-82e0-4fa4-bf7a-68c386204296]
==> oxide-instance.example: Date: [Fri, 20 Jun 2025 00:58:50 GMT]
==> oxide-instance.example: Content-Length: [153]
```