### PR TITLE
builder(instance): generate temporary ssh key pair

### DIFF
--- a/component/builder/instance/builder.go
+++ b/component/builder/instance/builder.go
@@ -56,7 +56,15 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		return nil, fmt.Errorf("failed creating oxide client: %w", err)
 	}
 
+	genTempKeyPair := len(b.config.SSHPublicKeys) == 0 ||
+		(b.config.Comm.SSHPrivateKeyFile == "" && !b.config.Comm.SSHAgentAuth)
+
 	steps := []multistep.Step{
+		multistep.If(genTempKeyPair, &communicator.StepSSHKeyGen{
+			CommConf:            &b.config.Comm,
+			SSHTemporaryKeyPair: b.config.Comm.SSH.SSHTemporaryKeyPair,
+		}),
+		multistep.If(genTempKeyPair, &stepSSHKeyCreate{}),
 		&stepInstanceCreate{},
 		&stepInstanceExternalIPList{},
 		&communicator.StepConnect{

--- a/component/builder/instance/step_instance_create.go
+++ b/component/builder/instance/step_instance_create.go
@@ -66,6 +66,11 @@ func (o *stepInstanceCreate) Run(ctx context.Context, stateBag multistep.StateBa
 			SshPublicKeys: func(sshPublicKeys []string) []oxide.NameOrId {
 				res := make([]oxide.NameOrId, 0, len(sshPublicKeys))
 
+				if sshKeyIDRaw, ok := stateBag.GetOk("ssh_key_id"); ok {
+					sshKeyID := sshKeyIDRaw.(string)
+					res = append(res, oxide.NameOrId(sshKeyID))
+				}
+
 				for _, sshPublicKey := range sshPublicKeys {
 					res = append(res, oxide.NameOrId(sshPublicKey))
 				}

--- a/component/builder/instance/step_ssh_key_create.go
+++ b/component/builder/instance/step_ssh_key_create.go
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package instance
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+var _ multistep.Step = (*stepSSHKeyCreate)(nil)
+
+// stepSSHKeyCreate is a Packer plugin step to create an SSH key.
+type stepSSHKeyCreate struct{}
+
+// Run creates an SSH key and stores its information in stateBag.
+func (s *stepSSHKeyCreate) Run(ctx context.Context, stateBag multistep.StateBag) multistep.StepAction {
+	oxideClient := stateBag.Get("client").(*oxide.Client)
+	ui := stateBag.Get("ui").(packer.Ui)
+	config := stateBag.Get("config").(*Config)
+
+	if config.Comm.SSHPublicKey == nil {
+		ui.Say("No public SSH key found; skipping SSH public key create...")
+		return multistep.ActionContinue
+	}
+
+	ui.Say("Creating Oxide SSH key")
+
+	sshKey, err := oxideClient.CurrentUserSshKeyCreate(ctx, oxide.CurrentUserSshKeyCreateParams{
+		Body: &oxide.SshKeyCreate{
+			Description: "Created by Packer.",
+			Name:        oxide.Name(config.Name),
+			PublicKey:   string(config.Comm.SSHPublicKey),
+		},
+	})
+	if err != nil {
+		ui.Error("Failed creating Oxide SSH key.")
+		stateBag.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	ui.Sayf("Created Oxide SSH key: %s", sshKey.Id)
+
+	stateBag.Put("ssh_key_id", sshKey.Id)
+
+	return multistep.ActionContinue
+}
+
+// Cleanup deletes the resources created by [stepSSHKeyCreate.Run].
+func (s *stepSSHKeyCreate) Cleanup(stateBag multistep.StateBag) {
+	oxideClient := stateBag.Get("client").(*oxide.Client)
+	ui := stateBag.Get("ui").(packer.Ui)
+
+	if sshKeyIDRaw, ok := stateBag.GetOk("ssh_key_id"); ok {
+		sshKeyID := sshKeyIDRaw.(string)
+
+		ui.Sayf("Deleting Oxide SSH key: %s", sshKeyID)
+
+		instanceDeleteCtx, instanceDeleteCtxCancel := context.WithTimeout(context.TODO(), 30*time.Second)
+		defer instanceDeleteCtxCancel()
+
+		if err := oxideClient.CurrentUserSshKeyDelete(instanceDeleteCtx, oxide.CurrentUserSshKeyDeleteParams{
+			SshKey: oxide.NameOrId(sshKeyID),
+		}); err != nil {
+			ui.Errorf("Failed deleting Oxide SSH key during cleanup. Please delete it manually: %v", err)
+			return
+		}
+	}
+}


### PR DESCRIPTION
Added support for generating a temporary SSH key pair when no other valid SSH key pair configuration is supplied. This allows users to more easily build images on Oxide since they no longer have to pre-create an SSH key pair and upload the public key to Oxide.

I need to complete a few more things before this is ready for review.
- [ ] Finalize the logic for choosing to generate a temporary SSH key pair. See the notes in https://developer.hashicorp.com/packer/docs/communicators/ssh to help.
- [ ] Update the UI logs for the newly created step.