### PR TITLE
builder(instance): fix panic when build is interrupted

### DIFF
--- a/component/builder/instance/builder.go
+++ b/component/builder/instance/builder.go
@@ -97,6 +97,13 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		return nil, err.(error)
 	}
 
+	_, hasImageID := stateBag.GetOk("image_id")
+	_, hasImageName := stateBag.GetOk("image_name")
+	if !hasImageID || !hasImageName {
+		ui.Say("No image_id or image_name. Skipping artifact creation.")
+		return nil, nil
+	}
+
 	artifact := &Artifact{
 		ImageID:   stateBag.Get("image_id").(string),
 		ImageName: stateBag.Get("image_name").(string),

--- a/component/builder/instance/step_instance_create.go
+++ b/component/builder/instance/step_instance_create.go
@@ -87,6 +87,9 @@ func (o *stepInstanceCreate) Run(ctx context.Context, stateBag multistep.StateBa
 
 	ui.Sayf("Created Oxide instance: %s", instance.Id)
 
+	stateBag.Put("instance_id", instance.Id)
+	stateBag.Put("boot_disk_id", instance.BootDiskId)
+
 	ui.Sayf("Waiting for Oxide instance to start: Currently %s.", instance.RunState)
 
 	startCtx, startCtxCancel := context.WithTimeout(ctx, 30*time.Second)
@@ -117,9 +120,6 @@ func (o *stepInstanceCreate) Run(ctx context.Context, stateBag multistep.StateBa
 		ui.Say(fmt.Sprintf("Waiting for Oxide instance to start: Currently %s.", instance.RunState))
 		time.Sleep(3 * time.Second)
 	}
-
-	stateBag.Put("instance_id", instance.Id)
-	stateBag.Put("boot_disk_id", instance.BootDiskId)
 
 	return multistep.ActionContinue
 }


### PR DESCRIPTION
Fixed an issue where Packer would panic when the build is interrupted. The panic occurred because the state bag was missing `image_id` and `image_name` elements but the artifact construction was performing a type assert on those elements unconditionally.

While in the code I noticed an issue where the instance create step would fail to clean up a running instance if the build was interrupted while the step was waiting for the instance to start. Similar to above, this was because the `instance_id` and `boot_disk_id` elements were not in the state bag and the `Cleanup` method conditionally cleans up the resources based on those elements.