### PR TITLE
builder(instance): add arguments to customize artifact

### DIFF
--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -40,6 +40,8 @@ or optional.
 - `project` (string) - Name or ID of the project where the temporary instance and resulting image
   will be created.
 
+- `artifact_os` (string) - Operating system of the resulting image artifact.
+
 <!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->
 
 
@@ -69,6 +71,8 @@ or optional.
 
 - `artifact_name` (string) - Name of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
 
+- `artifact_version` (string) - Version of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
+
 <!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->
 
 
@@ -80,7 +84,7 @@ A [`communicator`](/docs/communicators) can be configured for the builder.
 
 The builder automatically generates a temporary SSH key pair that's used to
 connect to the temporary instance unless one of the following SSH communicator
-attributes are set.
+arguments are set.
 
 - [`ssh_password`](/docs/communicators/ssh#ssh_password)
 - [`ssh_private_key_file`](/docs/communicators/ssh#ssh_private_key_file)
@@ -92,7 +96,7 @@ Packer to connect to the instance.
 
 The name of the temporary SSH public key uploaded to Oxide can be set using the
 [`temporary_key_pair_name`](/docs/communicators/ssh#temporary_key_pair_name)
-attribute. Generally there's no reason to set this but it's available should it
+argument. Generally there's no reason to set this but it's available should it
 be necessary.
 
 ## Provisioner
@@ -153,6 +157,7 @@ with the builder.
 source "oxide-instance" "example" {
   project            = "packer-acc-test"
   boot_disk_image_id = "feb2c8ee-5a1d-4d66-beeb-289b860561bf"
+  artifact_os        = "ubuntu"
 
   # SSH communicator configuration.
   ssh_username = "ubuntu"

--- a/component/builder/instance/builder_test.go
+++ b/component/builder/instance/builder_test.go
@@ -25,7 +25,7 @@ import (
 var packerTemplates embed.FS
 
 // TestAccBuilder_Config tests that the builder fails when required
-// configuration attributes are not provided.
+// configuration arguments are not provided.
 func TestAccBuilder_Config(t *testing.T) {
 	if os.Getenv(acctest.TestEnvVar) == "" {
 		t.Skipf("Acceptance tests skipped unless env '%s' set", acctest.TestEnvVar)
@@ -63,6 +63,7 @@ func TestAccBuilder_Config(t *testing.T) {
 				struct {
 					Project         string
 					BootDiskImageID string
+					ArtifactOS      string
 				}{},
 			),
 			Check: func(buildCommand *exec.Cmd, logfile string) error {
@@ -76,6 +77,7 @@ func TestAccBuilder_Config(t *testing.T) {
 				assertFileContains(t, logfile, "token is required")
 				assertFileContains(t, logfile, "project is required")
 				assertFileContains(t, logfile, "boot_disk_image_id is required")
+				assertFileContains(t, logfile, "artifact_os is required")
 
 				return nil
 			},
@@ -99,9 +101,11 @@ func TestAccBuilder_Config(t *testing.T) {
 				struct {
 					Project         string
 					BootDiskImageID string
+					ArtifactOS      string
 				}{
 					Project:         "test-project",
-					BootDiskImageID: "test-image-id",
+					BootDiskImageID: "test-boot-disk-image-id",
+					ArtifactOS:      "test-artifact-os",
 				},
 			),
 			Check: func(buildCommand *exec.Cmd, logfile string) error {
@@ -136,8 +140,10 @@ func TestAccBuilder_Config(t *testing.T) {
 				struct {
 					Project         string
 					BootDiskImageID string
+					ArtifactOS      string
 				}{
-					BootDiskImageID: "test-image-id",
+					BootDiskImageID: "test-boot-disk-image-id",
+					ArtifactOS:      "test-artifact-os",
 				},
 			),
 			Check: func(buildCommand *exec.Cmd, logfile string) error {
@@ -159,10 +165,12 @@ func TestAccBuilder_Config(t *testing.T) {
 				t,
 				"config.pkr.hcl.tmpl",
 				struct {
-					BootDiskImageID string
 					Project         string
+					BootDiskImageID string
+					ArtifactOS      string
 				}{
-					Project: "test-project",
+					Project:    "test-project",
+					ArtifactOS: "test-artifact-os",
 				},
 			),
 			Check: func(buildCommand *exec.Cmd, logfile string) error {
@@ -250,6 +258,7 @@ func TestAccBuilder_Instance(t *testing.T) {
 			// fields without creating some other mechanism to share state.
 			testID := fmt.Sprintf("packer-%d", time.Now().UnixNano())
 			artifactName := fmt.Sprintf("%s-%s", testID, "artifact")
+			artifactOS := fmt.Sprintf("%s-%s", testID, "artifact-os")
 
 			var packerTemplate strings.Builder
 			if err := tmpl.ExecuteTemplate(&packerTemplate, "instance.pkr.hcl.tmpl", struct {
@@ -259,6 +268,7 @@ func TestAccBuilder_Instance(t *testing.T) {
 				Memory          uint64
 				BootDiskSize    uint64
 				ArtifactName    string
+				ArtifactOS      string
 			}{
 				Project:         tc.project,
 				BootDiskImageID: tc.bootDiskImageID,
@@ -266,6 +276,7 @@ func TestAccBuilder_Instance(t *testing.T) {
 				Memory:          tc.memory,
 				BootDiskSize:    tc.bootDiskSize,
 				ArtifactName:    artifactName,
+				ArtifactOS:      artifactOS,
 			},
 			); err != nil {
 				t.Fatalf("failed rendering packer template: %v", err)

--- a/component/builder/instance/config.go
+++ b/component/builder/instance/config.go
@@ -77,6 +77,12 @@ type Config struct {
 	// Name of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
 	ArtifactName string `mapstructure:"artifact_name"`
 
+	// Operating system of the resulting image artifact.
+	ArtifactOS string `mapstructure:"artifact_os" required:"true"`
+
+	// Version of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
+	ArtifactVersion string `mapstructure:"artifact_version"`
+
 	ctx interpolate.Context
 }
 
@@ -128,6 +134,15 @@ func (c *Config) Prepare(args ...any) ([]string, error) {
 			}
 
 			c.ArtifactName = artifactName
+		}
+
+		if c.ArtifactVersion == "" {
+			artifactVersion, err := interpolate.Render("packer-{{timestamp}}", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed rendering default artifact version, this bug should be reported: %w", err)
+			}
+
+			c.ArtifactVersion = artifactVersion
 		}
 
 		if c.CPUs == 0 {
@@ -184,6 +199,10 @@ func (c *Config) Prepare(args ...any) ([]string, error) {
 
 		if c.BootDiskImageID == "" {
 			multiErr = packer.MultiErrorAppend(multiErr, errors.New("boot_disk_image_id is required"))
+		}
+
+		if c.ArtifactOS == "" {
+			multiErr = packer.MultiErrorAppend(multiErr, errors.New("artifact_os is required"))
 		}
 
 		if multiErr != nil && len(multiErr.Errors) > 0 {

--- a/component/builder/instance/config.hcl2spec.go
+++ b/component/builder/instance/config.hcl2spec.go
@@ -81,6 +81,8 @@ type FlatConfig struct {
 	Memory                    *uint64           `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	SSHPublicKeys             []string          `mapstructure:"ssh_public_keys" cty:"ssh_public_keys" hcl:"ssh_public_keys"`
 	ArtifactName              *string           `mapstructure:"artifact_name" cty:"artifact_name" hcl:"artifact_name"`
+	ArtifactOS                *string           `mapstructure:"artifact_os" required:"true" cty:"artifact_os" hcl:"artifact_os"`
+	ArtifactVersion           *string           `mapstructure:"artifact_version" cty:"artifact_version" hcl:"artifact_version"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -166,6 +168,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"ssh_public_keys":              &hcldec.AttrSpec{Name: "ssh_public_keys", Type: cty.List(cty.String), Required: false},
 		"artifact_name":                &hcldec.AttrSpec{Name: "artifact_name", Type: cty.String, Required: false},
+		"artifact_os":                  &hcldec.AttrSpec{Name: "artifact_os", Type: cty.String, Required: false},
+		"artifact_version":             &hcldec.AttrSpec{Name: "artifact_version", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/component/builder/instance/step_image_create.go
+++ b/component/builder/instance/step_image_create.go
@@ -32,12 +32,12 @@ func (s *stepImageCreate) Run(ctx context.Context, stateBag multistep.StateBag) 
 		Body: &oxide.ImageCreate{
 			Description: "Created by Packer.",
 			Name:        oxide.Name(config.ArtifactName),
-			Os:          "Packer",
+			Os:          config.ArtifactOS,
 			Source: oxide.ImageSource{
 				Type: oxide.ImageSourceTypeSnapshot,
 				Id:   snapshotID,
 			},
-			Version: "1.0",
+			Version: config.ArtifactVersion,
 		},
 	})
 	if err != nil {

--- a/component/builder/instance/testdata/config.pkr.hcl.tmpl
+++ b/component/builder/instance/testdata/config.pkr.hcl.tmpl
@@ -5,6 +5,9 @@ source "oxide-instance" "test" {
   {{- if .BootDiskImageID }}
   boot_disk_image_id = "{{ .BootDiskImageID }}"
   {{- end }}
+  {{- if .ArtifactOS }}
+  artifact_os = "{{ .ArtifactOS }}"
+  {{- end }}
 
   # To build the image without connecting to it during tests.
   communicator = "none"

--- a/component/builder/instance/testdata/instance.pkr.hcl.tmpl
+++ b/component/builder/instance/testdata/instance.pkr.hcl.tmpl
@@ -17,6 +17,9 @@ source "oxide-instance" "test" {
   {{- if .ArtifactName }}
   artifact_name = "{{ .ArtifactName }}"
   {{- end }}
+  {{- if .ArtifactOS }}
+  artifact_os = "{{ .ArtifactOS }}"
+  {{- end }}
 
   # To build the image without connecting to it during tests.
   communicator = "none"

--- a/component/data-source/image/data_source_test.go
+++ b/component/data-source/image/data_source_test.go
@@ -25,7 +25,7 @@ import (
 var packerTemplates embed.FS
 
 // TestAccDataSource_Config tests that the data source fails when required
-// configuration attributes are not provided.
+// configuration arguments are not provided.
 func TestAccDataSource_Config(t *testing.T) {
 	if os.Getenv(acctest.TestEnvVar) == "" {
 		t.Skipf("Acceptance tests skipped unless env '%s' set", acctest.TestEnvVar)

--- a/docs-partials/component/builder/instance/Config-not-required.mdx
+++ b/docs-partials/component/builder/instance/Config-not-required.mdx
@@ -22,4 +22,6 @@
 
 - `artifact_name` (string) - Name of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
 
+- `artifact_version` (string) - Version of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
+
 <!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->

--- a/docs-partials/component/builder/instance/Config-required.mdx
+++ b/docs-partials/component/builder/instance/Config-required.mdx
@@ -12,4 +12,6 @@
 - `project` (string) - Name or ID of the project where the temporary instance and resulting image
   will be created.
 
+- `artifact_os` (string) - Operating system of the resulting image artifact.
+
 <!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->

--- a/docs/builders/instance.mdx
+++ b/docs/builders/instance.mdx
@@ -35,7 +35,7 @@ A [`communicator`](/docs/communicators) can be configured for the builder.
 
 The builder automatically generates a temporary SSH key pair that's used to
 connect to the temporary instance unless one of the following SSH communicator
-attributes are set.
+arguments are set.
 
 - [`ssh_password`](/docs/communicators/ssh#ssh_password)
 - [`ssh_private_key_file`](/docs/communicators/ssh#ssh_private_key_file)
@@ -47,7 +47,7 @@ Packer to connect to the instance.
 
 The name of the temporary SSH public key uploaded to Oxide can be set using the
 [`temporary_key_pair_name`](/docs/communicators/ssh#temporary_key_pair_name)
-attribute. Generally there's no reason to set this but it's available should it
+argument. Generally there's no reason to set this but it's available should it
 be necessary.
 
 ## Provisioner
@@ -108,6 +108,7 @@ with the builder.
 source "oxide-instance" "example" {
   project            = "packer-acc-test"
   boot_disk_image_id = "feb2c8ee-5a1d-4d66-beeb-289b860561bf"
+  artifact_os        = "ubuntu"
 
   # SSH communicator configuration.
   ssh_username = "ubuntu"

--- a/example/template.pkr.hcl
+++ b/example/template.pkr.hcl
@@ -14,6 +14,7 @@ data "oxide-image" "ubuntu" {
 source "oxide-instance" "example" {
   project            = "packer-acc-test"
   boot_disk_image_id = data.oxide-image.ubuntu.image_id
+  artifact_os        = "ubuntu"
 
   # Do not connect to the temporary instance.
   communicator = "none"


### PR DESCRIPTION
Added the following configuration arguments to allow users to customize the resulting image artifact.

* `artifact_os`
* `artifact_version`