### PR TITLE
builder(instance): set artifact information from source image

### DIFF
--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -40,8 +40,6 @@ or optional.
 - `project` (string) - Name or ID of the project where the temporary instance and resulting image
   will be created.
 
-- `artifact_os` (string) - Operating system of the resulting image artifact.
-
 <!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->
 
 
@@ -69,9 +67,16 @@ or optional.
 
 - `ssh_public_keys` ([]string) - An array of names or IDs of SSH public keys to inject into the instance.
 
-- `artifact_name` (string) - Name of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
+- `artifact_name` (string) - Name of the resulting image artifact. Defaults to
+  `SOURCE_IMAGE_NAME-{{timestamp}}` where `SOURCE_IMAGE_NAME` is the name of
+  the source image as retrieved from Oxide.
 
-- `artifact_version` (string) - Version of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
+- `artifact_os` (string) - Operating system of the resulting image artifact. Defaults to the OS of the
+  source image as retrieved from Oxide.
+
+- `artifact_version` (string) - Version of the resulting image artifact. Defaults to
+  `SOURCE_IMAGE_VERSION-{{timestamp}}` where `SOURCE_IMAGE_VERSION` is the
+  version of the source image as retrieved from Oxide.
 
 <!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->
 
@@ -157,7 +162,6 @@ with the builder.
 source "oxide-instance" "example" {
   project            = "packer-acc-test"
   boot_disk_image_id = "feb2c8ee-5a1d-4d66-beeb-289b860561bf"
-  artifact_os        = "ubuntu"
 
   # SSH communicator configuration.
   ssh_username = "ubuntu"

--- a/component/builder/instance/builder.go
+++ b/component/builder/instance/builder.go
@@ -66,6 +66,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		!b.config.Comm.SSHAgentAuth
 
 	steps := []multistep.Step{
+		&stepImageView{},
 		multistep.If(genTempSSHKeyPair, &communicator.StepSSHKeyGen{
 			CommConf:            &b.config.Comm,
 			SSHTemporaryKeyPair: b.config.Comm.SSH.SSHTemporaryKeyPair,

--- a/component/builder/instance/builder_test.go
+++ b/component/builder/instance/builder_test.go
@@ -63,7 +63,6 @@ func TestAccBuilder_Config(t *testing.T) {
 				struct {
 					Project         string
 					BootDiskImageID string
-					ArtifactOS      string
 				}{},
 			),
 			Check: func(buildCommand *exec.Cmd, logfile string) error {
@@ -77,7 +76,6 @@ func TestAccBuilder_Config(t *testing.T) {
 				assertFileContains(t, logfile, "token is required")
 				assertFileContains(t, logfile, "project is required")
 				assertFileContains(t, logfile, "boot_disk_image_id is required")
-				assertFileContains(t, logfile, "artifact_os is required")
 
 				return nil
 			},
@@ -101,11 +99,9 @@ func TestAccBuilder_Config(t *testing.T) {
 				struct {
 					Project         string
 					BootDiskImageID string
-					ArtifactOS      string
 				}{
 					Project:         "test-project",
 					BootDiskImageID: "test-boot-disk-image-id",
-					ArtifactOS:      "test-artifact-os",
 				},
 			),
 			Check: func(buildCommand *exec.Cmd, logfile string) error {
@@ -140,10 +136,8 @@ func TestAccBuilder_Config(t *testing.T) {
 				struct {
 					Project         string
 					BootDiskImageID string
-					ArtifactOS      string
 				}{
 					BootDiskImageID: "test-boot-disk-image-id",
-					ArtifactOS:      "test-artifact-os",
 				},
 			),
 			Check: func(buildCommand *exec.Cmd, logfile string) error {
@@ -167,10 +161,8 @@ func TestAccBuilder_Config(t *testing.T) {
 				struct {
 					Project         string
 					BootDiskImageID string
-					ArtifactOS      string
 				}{
 					Project:    "test-project",
-					ArtifactOS: "test-artifact-os",
 				},
 			),
 			Check: func(buildCommand *exec.Cmd, logfile string) error {
@@ -233,7 +225,6 @@ func TestAccBuilder_Instance(t *testing.T) {
 		cpus            uint64
 		memory          uint64
 		bootDiskSize    uint64
-		artifactName    string
 	}{
 		{
 			testName:        "DefaultConfiguration",
@@ -258,7 +249,6 @@ func TestAccBuilder_Instance(t *testing.T) {
 			// fields without creating some other mechanism to share state.
 			testID := fmt.Sprintf("packer-%d", time.Now().UnixNano())
 			artifactName := fmt.Sprintf("%s-%s", testID, "artifact")
-			artifactOS := fmt.Sprintf("%s-%s", testID, "artifact-os")
 
 			var packerTemplate strings.Builder
 			if err := tmpl.ExecuteTemplate(&packerTemplate, "instance.pkr.hcl.tmpl", struct {
@@ -268,7 +258,6 @@ func TestAccBuilder_Instance(t *testing.T) {
 				Memory          uint64
 				BootDiskSize    uint64
 				ArtifactName    string
-				ArtifactOS      string
 			}{
 				Project:         tc.project,
 				BootDiskImageID: tc.bootDiskImageID,
@@ -276,7 +265,6 @@ func TestAccBuilder_Instance(t *testing.T) {
 				Memory:          tc.memory,
 				BootDiskSize:    tc.bootDiskSize,
 				ArtifactName:    artifactName,
-				ArtifactOS:      artifactOS,
 			},
 			); err != nil {
 				t.Fatalf("failed rendering packer template: %v", err)

--- a/component/builder/instance/config.go
+++ b/component/builder/instance/config.go
@@ -74,13 +74,18 @@ type Config struct {
 	// An array of names or IDs of SSH public keys to inject into the instance.
 	SSHPublicKeys []string `mapstructure:"ssh_public_keys"`
 
-	// Name of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
+	// Name of the resulting image artifact. Defaults to
+	// `SOURCE_IMAGE_NAME-{{timestamp}}` where `SOURCE_IMAGE_NAME` is the name of
+	// the source image as retrieved from Oxide.
 	ArtifactName string `mapstructure:"artifact_name"`
 
-	// Operating system of the resulting image artifact.
-	ArtifactOS string `mapstructure:"artifact_os" required:"true"`
+	// Operating system of the resulting image artifact. Defaults to the OS of the
+	// source image as retrieved from Oxide.
+	ArtifactOS string `mapstructure:"artifact_os"`
 
-	// Version of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
+	// Version of the resulting image artifact. Defaults to
+	// `SOURCE_IMAGE_VERSION-{{timestamp}}` where `SOURCE_IMAGE_VERSION` is the
+	// version of the source image as retrieved from Oxide.
 	ArtifactVersion string `mapstructure:"artifact_version"`
 
 	ctx interpolate.Context
@@ -125,24 +130,6 @@ func (c *Config) Prepare(args ...any) ([]string, error) {
 			}
 
 			c.Hostname = hostname
-		}
-
-		if c.ArtifactName == "" {
-			artifactName, err := interpolate.Render("packer-{{timestamp}}", nil)
-			if err != nil {
-				return nil, fmt.Errorf("failed rendering default artifact name, this bug should be reported: %w", err)
-			}
-
-			c.ArtifactName = artifactName
-		}
-
-		if c.ArtifactVersion == "" {
-			artifactVersion, err := interpolate.Render("packer-{{timestamp}}", nil)
-			if err != nil {
-				return nil, fmt.Errorf("failed rendering default artifact version, this bug should be reported: %w", err)
-			}
-
-			c.ArtifactVersion = artifactVersion
 		}
 
 		if c.CPUs == 0 {
@@ -201,9 +188,6 @@ func (c *Config) Prepare(args ...any) ([]string, error) {
 			multiErr = packer.MultiErrorAppend(multiErr, errors.New("boot_disk_image_id is required"))
 		}
 
-		if c.ArtifactOS == "" {
-			multiErr = packer.MultiErrorAppend(multiErr, errors.New("artifact_os is required"))
-		}
 
 		if multiErr != nil && len(multiErr.Errors) > 0 {
 			return nil, multiErr

--- a/component/builder/instance/config.hcl2spec.go
+++ b/component/builder/instance/config.hcl2spec.go
@@ -81,7 +81,7 @@ type FlatConfig struct {
 	Memory                    *uint64           `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	SSHPublicKeys             []string          `mapstructure:"ssh_public_keys" cty:"ssh_public_keys" hcl:"ssh_public_keys"`
 	ArtifactName              *string           `mapstructure:"artifact_name" cty:"artifact_name" hcl:"artifact_name"`
-	ArtifactOS                *string           `mapstructure:"artifact_os" required:"true" cty:"artifact_os" hcl:"artifact_os"`
+	ArtifactOS                *string           `mapstructure:"artifact_os" cty:"artifact_os" hcl:"artifact_os"`
 	ArtifactVersion           *string           `mapstructure:"artifact_version" cty:"artifact_version" hcl:"artifact_version"`
 }
 

--- a/component/builder/instance/step_image_view.go
+++ b/component/builder/instance/step_image_view.go
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package instance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+var _ multistep.Step = (*stepImageView)(nil)
+
+// stepImageView is a Packer plugin step to fetch an Oxide image.
+type stepImageView struct{}
+
+// Run fetches an Oxide image and populate configuration arguments.
+func (s *stepImageView) Run(ctx context.Context, stateBag multistep.StateBag) multistep.StepAction {
+	oxideClient := stateBag.Get("client").(*oxide.Client)
+	ui := stateBag.Get("ui").(packer.Ui)
+	config := stateBag.Get("config").(*Config)
+
+	ui.Say("Fetching source image metadata")
+
+	image, err := oxideClient.ImageView(ctx, oxide.ImageViewParams{
+		Image: oxide.NameOrId(config.BootDiskImageID),
+	})
+	if err != nil {
+		ui.Error("Failed fetching source image metadata.")
+		stateBag.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	ui.Sayf("Fetched source image: %s", image.Id)
+
+	timestamp, err := interpolate.Render("{{timestamp}}", &config.ctx)
+	if err != nil {
+		ui.Error("Failed rendering timestamp.")
+		stateBag.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	if config.ArtifactName == "" {
+		config.ArtifactName = fmt.Sprintf("%s-%s", image.Name, timestamp)
+	}
+
+	if config.ArtifactOS == "" {
+		config.ArtifactOS = image.Os
+	}
+
+	if config.ArtifactVersion == "" {
+		config.ArtifactVersion = fmt.Sprintf("%s-%s", image.Version, timestamp)
+	}
+
+	return multistep.ActionContinue
+}
+
+// Cleanup deletes the resources created by [stepImageView.Run].
+func (s *stepImageView) Cleanup(stateBag multistep.StateBag) {}

--- a/component/builder/instance/testdata/config.pkr.hcl.tmpl
+++ b/component/builder/instance/testdata/config.pkr.hcl.tmpl
@@ -5,9 +5,6 @@ source "oxide-instance" "test" {
   {{- if .BootDiskImageID }}
   boot_disk_image_id = "{{ .BootDiskImageID }}"
   {{- end }}
-  {{- if .ArtifactOS }}
-  artifact_os = "{{ .ArtifactOS }}"
-  {{- end }}
 
   # To build the image without connecting to it during tests.
   communicator = "none"

--- a/component/builder/instance/testdata/instance.pkr.hcl.tmpl
+++ b/component/builder/instance/testdata/instance.pkr.hcl.tmpl
@@ -17,9 +17,6 @@ source "oxide-instance" "test" {
   {{- if .ArtifactName }}
   artifact_name = "{{ .ArtifactName }}"
   {{- end }}
-  {{- if .ArtifactOS }}
-  artifact_os = "{{ .ArtifactOS }}"
-  {{- end }}
 
   # To build the image without connecting to it during tests.
   communicator = "none"

--- a/docs-partials/component/builder/instance/Config-not-required.mdx
+++ b/docs-partials/component/builder/instance/Config-not-required.mdx
@@ -20,8 +20,15 @@
 
 - `ssh_public_keys` ([]string) - An array of names or IDs of SSH public keys to inject into the instance.
 
-- `artifact_name` (string) - Name of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
+- `artifact_name` (string) - Name of the resulting image artifact. Defaults to
+  `SOURCE_IMAGE_NAME-{{timestamp}}` where `SOURCE_IMAGE_NAME` is the name of
+  the source image as retrieved from Oxide.
 
-- `artifact_version` (string) - Version of the resulting image artifact. Defaults to `packer-{{timestamp}}`.
+- `artifact_os` (string) - Operating system of the resulting image artifact. Defaults to the OS of the
+  source image as retrieved from Oxide.
+
+- `artifact_version` (string) - Version of the resulting image artifact. Defaults to
+  `SOURCE_IMAGE_VERSION-{{timestamp}}` where `SOURCE_IMAGE_VERSION` is the
+  version of the source image as retrieved from Oxide.
 
 <!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->

--- a/docs-partials/component/builder/instance/Config-required.mdx
+++ b/docs-partials/component/builder/instance/Config-required.mdx
@@ -12,6 +12,4 @@
 - `project` (string) - Name or ID of the project where the temporary instance and resulting image
   will be created.
 
-- `artifact_os` (string) - Operating system of the resulting image artifact.
-
 <!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->

--- a/docs/builders/instance.mdx
+++ b/docs/builders/instance.mdx
@@ -108,7 +108,6 @@ with the builder.
 source "oxide-instance" "example" {
   project            = "packer-acc-test"
   boot_disk_image_id = "feb2c8ee-5a1d-4d66-beeb-289b860561bf"
-  artifact_os        = "ubuntu"
 
   # SSH communicator configuration.
   ssh_username = "ubuntu"

--- a/example/template.pkr.hcl
+++ b/example/template.pkr.hcl
@@ -14,7 +14,6 @@ data "oxide-image" "ubuntu" {
 source "oxide-instance" "example" {
   project            = "packer-acc-test"
   boot_disk_image_id = data.oxide-image.ubuntu.image_id
-  artifact_os        = "ubuntu"
 
   # Do not connect to the temporary instance.
   communicator = "none"


### PR DESCRIPTION
Added a new step to fetch the source image information so that it can be used to set defaults for the resulting image artifact. This allows users to omit all of the `artifact_*` configuration arguments if desired.