### PR TITLE
misc: update component slug metadata

### DIFF
--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -16,11 +16,11 @@ integration {
   component {
     type = "builder"
     name = "Oxide Instance"
-    slug = "oxide-instance"
+    slug = "instance"
   }
   component {
     type = "data-source"
     name = "Oxide Image"
-    slug = "oxide-image"
+    slug = "image"
   }
 }


### PR DESCRIPTION
Updated the `slug` components within the `metadata.hcl` file so that the documentation for the component is correctly rendered in the `HashiCorp Integration Release` GitHub Actions workflows.

The `slug` must match the component name as listed in `docs/COMPONENT/NAME` otherwise the workflow would render a `null` README for the component.

```
    "components": [
      {
        "type": "builder",
        "name": "Oxide Instance",
        "slug": "oxide-instance",
        "readme": null,
        "variable_groups": []
      },
      {
        "type": "data-source",
        "name": "Oxide Image",
        "slug": "oxide-image",
        "readme": null,
        "variable_groups": []
      }
    ]
```

With this change the component README is non-null.

```
    "components": [
      {
        "type": "builder",
        "name": "Oxide Instance",
        "slug": "instance",
        "readme": "Type: `oxide-instance`\n\n<!-- Code generated from the comments of the Builder struct in component/builder/instance/builder.go; DO NOT EDIT MANUALLY -->",
        "variable_groups": []
      },
      {
        "type": "data-source",
        "name": "Oxide Image",
        "slug": "image",
        "readme": "Type: `oxide-image`\n\n<!-- Code generated from the comments of the Datasource struct in component/data-source/image/data_source.go; DO NOT EDIT MANUALLY -->",
        "variable_groups": []
      }
    ]
```