### PR TITLE
feat: support credentials profiles

### DIFF
--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -28,12 +28,6 @@ or optional.
 
 <!-- Code generated from the comments of the Config struct in component/builder/instance/config.go; DO NOT EDIT MANUALLY -->
 
-- `host` (string) - Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified, this
-  defaults to the value of the `OXIDE_HOST` environment variable.
-
-- `token` (string) - Oxide API token. If not specified, this defaults to the value of the
-  `OXIDE_TOKEN` environment variable.
-
 - `boot_disk_image_id` (string) - Image ID to use for the instance's boot disk. This can be obtained from the
   `oxide-image` data source.
 
@@ -46,6 +40,17 @@ or optional.
 ### Optional
 
 <!-- Code generated from the comments of the Config struct in component/builder/instance/config.go; DO NOT EDIT MANUALLY -->
+
+- `host` (string) - Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified,
+  this defaults to the value of the `OXIDE_HOST` environment variable. When
+  specified, `token` must be specified. Conflicts with `profile`.
+
+- `token` (string) - Oxide API token. If not specified, this defaults to the value of the
+  `OXIDE_TOKEN` environment variable. When specified, `host` must be specified.
+  Conflicts with `profile`.
+
+- `profile` (string) - Oxide credentials profile. If not specified, this defaults to the value of
+  the `OXIDE_PROFILE` environment variable. Conflicts with `host` and `token`.
 
 - `boot_disk_size` (uint64) - Size of the boot disk in bytes. Defaults to `21474836480`, or 20 GiB.
 

--- a/.web-docs/components/data-source/image/README.md
+++ b/.web-docs/components/data-source/image/README.md
@@ -23,12 +23,6 @@ required or optional.
 
 <!-- Code generated from the comments of the Config struct in component/data-source/image/config.go; DO NOT EDIT MANUALLY -->
 
-- `host` (string) - Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified, this
-  defaults to the value of the `OXIDE_HOST` environment variable.
-
-- `token` (string) - Oxide API token. If not specified, this defaults to the value of the
-  `OXIDE_TOKEN` environment variable.
-
 - `name` (string) - Name of the image to fetch.
 
 <!-- End of code generated from the comments of the Config struct in component/data-source/image/config.go; -->
@@ -37,6 +31,17 @@ required or optional.
 ### Optional
 
 <!-- Code generated from the comments of the Config struct in component/data-source/image/config.go; DO NOT EDIT MANUALLY -->
+
+- `host` (string) - Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified,
+  this defaults to the value of the `OXIDE_HOST` environment variable. When
+  specified, `token` must be specified. Conflicts with `profile`.
+
+- `token` (string) - Oxide API token. If not specified, this defaults to the value of the
+  `OXIDE_TOKEN` environment variable. When specified, `host` must be specified.
+  Conflicts with `profile`.
+
+- `profile` (string) - Oxide credentials profile. If not specified, this defaults to the value of
+  the `OXIDE_PROFILE` environment variable. Conflicts with `host` and `token`.
 
 - `project` (string) - Name or ID of the project containing the image to fetch. Leave blank to fetch
   a silo image instead of a project image.

--- a/component/builder/instance/builder.go
+++ b/component/builder/instance/builder.go
@@ -53,8 +53,9 @@ func (b *Builder) Prepare(args ...any) ([]string, []string, error) {
 // Run executes the builder steps to create an Oxide image.
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {
 	oxideClient, err := oxide.NewClient(&oxide.Config{
-		Host:  b.config.Host,
-		Token: b.config.Token,
+		Host:    b.config.Host,
+		Token:   b.config.Token,
+		Profile: b.config.Profile,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed creating oxide client: %w", err)

--- a/component/builder/instance/config.hcl2spec.go
+++ b/component/builder/instance/config.hcl2spec.go
@@ -67,8 +67,9 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
-	Host                      *string           `mapstructure:"host" required:"true" cty:"host" hcl:"host"`
-	Token                     *string           `mapstructure:"token" required:"true" cty:"token" hcl:"token"`
+	Host                      *string           `mapstructure:"host" required:"false" cty:"host" hcl:"host"`
+	Token                     *string           `mapstructure:"token" required:"false" cty:"token" hcl:"token"`
+	Profile                   *string           `mapstructure:"profile" required:"false" cty:"profile" hcl:"profile"`
 	BootDiskImageID           *string           `mapstructure:"boot_disk_image_id" required:"true" cty:"boot_disk_image_id" hcl:"boot_disk_image_id"`
 	Project                   *string           `mapstructure:"project" required:"true" cty:"project" hcl:"project"`
 	BootDiskSize              *uint64           `mapstructure:"boot_disk_size" cty:"boot_disk_size" hcl:"boot_disk_size"`
@@ -156,6 +157,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
 		"host":                         &hcldec.AttrSpec{Name: "host", Type: cty.String, Required: false},
 		"token":                        &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
+		"profile":                      &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
 		"boot_disk_image_id":           &hcldec.AttrSpec{Name: "boot_disk_image_id", Type: cty.String, Required: false},
 		"project":                      &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
 		"boot_disk_size":               &hcldec.AttrSpec{Name: "boot_disk_size", Type: cty.Number, Required: false},

--- a/component/data-source/image/config.go
+++ b/component/data-source/image/config.go
@@ -10,13 +10,19 @@ package image
 // The configuration arguments for the data source. Arguments can either be
 // required or optional.
 type Config struct {
-	// Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified, this
-	// defaults to the value of the `OXIDE_HOST` environment variable.
-	Host string `mapstructure:"host" required:"true"`
+	// Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified,
+	// this defaults to the value of the `OXIDE_HOST` environment variable. When
+	// specified, `token` must be specified. Conflicts with `profile`.
+	Host string `mapstructure:"host" required:"false"`
 
 	// Oxide API token. If not specified, this defaults to the value of the
-	// `OXIDE_TOKEN` environment variable.
-	Token string `mapstructure:"token" required:"true"`
+	// `OXIDE_TOKEN` environment variable. When specified, `host` must be specified.
+	// Conflicts with `profile`.
+	Token string `mapstructure:"token" required:"false"`
+
+	// Oxide credentials profile. If not specified, this defaults to the value of
+	// the `OXIDE_PROFILE` environment variable. Conflicts with `host` and `token`.
+	Profile string `mapstructure:"profile" required:"false"`
 
 	// Name of the image to fetch.
 	Name string `mapstructure:"name" required:"true"`

--- a/component/data-source/image/config.hcl2spec.go
+++ b/component/data-source/image/config.hcl2spec.go
@@ -10,8 +10,9 @@ import (
 // FlatConfig is an auto-generated flat version of Config.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatConfig struct {
-	Host    *string `mapstructure:"host" required:"true" cty:"host" hcl:"host"`
-	Token   *string `mapstructure:"token" required:"true" cty:"token" hcl:"token"`
+	Host    *string `mapstructure:"host" required:"false" cty:"host" hcl:"host"`
+	Token   *string `mapstructure:"token" required:"false" cty:"token" hcl:"token"`
+	Profile *string `mapstructure:"profile" required:"false" cty:"profile" hcl:"profile"`
 	Name    *string `mapstructure:"name" required:"true" cty:"name" hcl:"name"`
 	Project *string `mapstructure:"project" cty:"project" hcl:"project"`
 }
@@ -30,6 +31,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"host":    &hcldec.AttrSpec{Name: "host", Type: cty.String, Required: false},
 		"token":   &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
+		"profile": &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
 		"name":    &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
 		"project": &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
 	}

--- a/docs-partials/component/builder/instance/Config-not-required.mdx
+++ b/docs-partials/component/builder/instance/Config-not-required.mdx
@@ -1,5 +1,16 @@
 <!-- Code generated from the comments of the Config struct in component/builder/instance/config.go; DO NOT EDIT MANUALLY -->
 
+- `host` (string) - Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified,
+  this defaults to the value of the `OXIDE_HOST` environment variable. When
+  specified, `token` must be specified. Conflicts with `profile`.
+
+- `token` (string) - Oxide API token. If not specified, this defaults to the value of the
+  `OXIDE_TOKEN` environment variable. When specified, `host` must be specified.
+  Conflicts with `profile`.
+
+- `profile` (string) - Oxide credentials profile. If not specified, this defaults to the value of
+  the `OXIDE_PROFILE` environment variable. Conflicts with `host` and `token`.
+
 - `boot_disk_size` (uint64) - Size of the boot disk in bytes. Defaults to `21474836480`, or 20 GiB.
 
 - `ip_pool` (string) - IP pool to allocate the instance's external IP from. If not specified, the

--- a/docs-partials/component/builder/instance/Config-required.mdx
+++ b/docs-partials/component/builder/instance/Config-required.mdx
@@ -1,11 +1,5 @@
 <!-- Code generated from the comments of the Config struct in component/builder/instance/config.go; DO NOT EDIT MANUALLY -->
 
-- `host` (string) - Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified, this
-  defaults to the value of the `OXIDE_HOST` environment variable.
-
-- `token` (string) - Oxide API token. If not specified, this defaults to the value of the
-  `OXIDE_TOKEN` environment variable.
-
 - `boot_disk_image_id` (string) - Image ID to use for the instance's boot disk. This can be obtained from the
   `oxide-image` data source.
 

--- a/docs-partials/component/data-source/image/Config-not-required.mdx
+++ b/docs-partials/component/data-source/image/Config-not-required.mdx
@@ -1,5 +1,16 @@
 <!-- Code generated from the comments of the Config struct in component/data-source/image/config.go; DO NOT EDIT MANUALLY -->
 
+- `host` (string) - Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified,
+  this defaults to the value of the `OXIDE_HOST` environment variable. When
+  specified, `token` must be specified. Conflicts with `profile`.
+
+- `token` (string) - Oxide API token. If not specified, this defaults to the value of the
+  `OXIDE_TOKEN` environment variable. When specified, `host` must be specified.
+  Conflicts with `profile`.
+
+- `profile` (string) - Oxide credentials profile. If not specified, this defaults to the value of
+  the `OXIDE_PROFILE` environment variable. Conflicts with `host` and `token`.
+
 - `project` (string) - Name or ID of the project containing the image to fetch. Leave blank to fetch
   a silo image instead of a project image.
 

--- a/docs-partials/component/data-source/image/Config-required.mdx
+++ b/docs-partials/component/data-source/image/Config-required.mdx
@@ -1,11 +1,5 @@
 <!-- Code generated from the comments of the Config struct in component/data-source/image/config.go; DO NOT EDIT MANUALLY -->
 
-- `host` (string) - Oxide API URL (e.g., `https://oxide.sys.example.com`). If not specified, this
-  defaults to the value of the `OXIDE_HOST` environment variable.
-
-- `token` (string) - Oxide API token. If not specified, this defaults to the value of the
-  `OXIDE_TOKEN` environment variable.
-
 - `name` (string) - Name of the image to fetch.
 
 <!-- End of code generated from the comments of the Config struct in component/data-source/image/config.go; -->


### PR DESCRIPTION
Updated both the `instance` builder and `image` data source to support Oxide credentials profiles via the `profile` argument and the `OXIDE_PROFILE` environment variable.

Closes https://github.com/oxidecomputer/packer-plugin-oxide/issues/47.