### PR TITLE
Add `insecure_skip_verify` flag.

### DIFF
--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -52,6 +52,9 @@ or optional.
 - `profile` (string) - Oxide credentials profile. If not specified, this defaults to the value of
   the `OXIDE_PROFILE` environment variable. Conflicts with `host` and `token`.
 
+- `insecure_skip_verify` (bool) - Skip TLS certificate verification when connecting to the Oxide API.
+  Defaults to `false`.
+
 - `boot_disk_size` (uint64) - Size of the boot disk in bytes. Defaults to `21474836480`, or 20 GiB.
 
 - `ip_pool` (string) - IP pool to allocate the instance's external IP from. If not specified, the

--- a/.web-docs/components/data-source/image/README.md
+++ b/.web-docs/components/data-source/image/README.md
@@ -43,6 +43,9 @@ required or optional.
 - `profile` (string) - Oxide credentials profile. If not specified, this defaults to the value of
   the `OXIDE_PROFILE` environment variable. Conflicts with `host` and `token`.
 
+- `insecure_skip_verify` (bool) - Skip TLS certificate verification when connecting to the Oxide API.
+  Defaults to `false`.
+
 - `project` (string) - Name or ID of the project containing the image to fetch. Leave blank to fetch
   a silo image instead of a project image.
 

--- a/component/builder/instance/builder.go
+++ b/component/builder/instance/builder.go
@@ -62,6 +62,9 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	if b.config.Profile != "" {
 		opts = append(opts, oxide.WithProfile(b.config.Profile))
 	}
+	if b.config.InsecureSkipVerify {
+		opts = append(opts, oxide.WithInsecureSkipVerify())
+	}
 	oxideClient, err := oxide.NewClient(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating oxide client: %w", err)

--- a/component/builder/instance/builder_test.go
+++ b/component/builder/instance/builder_test.go
@@ -150,7 +150,13 @@ func TestAccBuilder_Instance(t *testing.T) {
 
 	tmpl := template.Must(template.ParseFS(packerTemplates, "testdata/*.pkr.hcl.tmpl"))
 
-	oxideClient, err := oxide.NewClient()
+	var oxideClientOpts []oxide.ClientOption
+	insecureSkipVerify := os.Getenv("OXIDE_INSECURE_SKIP_VERIFY") == "true"
+	if insecureSkipVerify {
+		oxideClientOpts = append(oxideClientOpts, oxide.WithInsecureSkipVerify())
+	}
+
+	oxideClient, err := oxide.NewClient(oxideClientOpts...)
 	if err != nil {
 		t.Fatalf("failed creating oxide client: %v", err)
 	}
@@ -200,19 +206,21 @@ func TestAccBuilder_Instance(t *testing.T) {
 
 			var packerTemplate strings.Builder
 			if err := tmpl.ExecuteTemplate(&packerTemplate, "instance.pkr.hcl.tmpl", struct {
-				Project         string
-				BootDiskImageID string
-				CPUs            uint64
-				Memory          uint64
-				BootDiskSize    uint64
-				ArtifactName    string
+				Project            string
+				BootDiskImageID    string
+				CPUs               uint64
+				Memory             uint64
+				BootDiskSize       uint64
+				ArtifactName       string
+				InsecureSkipVerify bool
 			}{
-				Project:         tc.project,
-				BootDiskImageID: tc.bootDiskImageID,
-				CPUs:            tc.cpus,
-				Memory:          tc.memory,
-				BootDiskSize:    tc.bootDiskSize,
-				ArtifactName:    artifactName,
+				Project:            tc.project,
+				BootDiskImageID:    tc.bootDiskImageID,
+				CPUs:               tc.cpus,
+				Memory:             tc.memory,
+				BootDiskSize:       tc.bootDiskSize,
+				ArtifactName:       artifactName,
+				InsecureSkipVerify: insecureSkipVerify,
 			},
 			); err != nil {
 				t.Fatalf("failed rendering packer template: %v", err)

--- a/component/builder/instance/config.go
+++ b/component/builder/instance/config.go
@@ -42,6 +42,10 @@ type Config struct {
 	// the `OXIDE_PROFILE` environment variable. Conflicts with `host` and `token`.
 	Profile string `mapstructure:"profile" required:"false"`
 
+	// Skip TLS certificate verification when connecting to the Oxide API.
+	// Defaults to `false`.
+	InsecureSkipVerify bool `mapstructure:"insecure_skip_verify" required:"false"`
+
 	// Image ID to use for the instance's boot disk. This can be obtained from the
 	// `oxide-image` data source.
 	BootDiskImageID string `mapstructure:"boot_disk_image_id" required:"true"`

--- a/component/builder/instance/config.hcl2spec.go
+++ b/component/builder/instance/config.hcl2spec.go
@@ -70,6 +70,7 @@ type FlatConfig struct {
 	Host                      *string           `mapstructure:"host" required:"false" cty:"host" hcl:"host"`
 	Token                     *string           `mapstructure:"token" required:"false" cty:"token" hcl:"token"`
 	Profile                   *string           `mapstructure:"profile" required:"false" cty:"profile" hcl:"profile"`
+	InsecureSkipVerify        *bool             `mapstructure:"insecure_skip_verify" required:"false" cty:"insecure_skip_verify" hcl:"insecure_skip_verify"`
 	BootDiskImageID           *string           `mapstructure:"boot_disk_image_id" required:"true" cty:"boot_disk_image_id" hcl:"boot_disk_image_id"`
 	Project                   *string           `mapstructure:"project" required:"true" cty:"project" hcl:"project"`
 	BootDiskSize              *uint64           `mapstructure:"boot_disk_size" cty:"boot_disk_size" hcl:"boot_disk_size"`
@@ -158,6 +159,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"host":                         &hcldec.AttrSpec{Name: "host", Type: cty.String, Required: false},
 		"token":                        &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
 		"profile":                      &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
+		"insecure_skip_verify":         &hcldec.AttrSpec{Name: "insecure_skip_verify", Type: cty.Bool, Required: false},
 		"boot_disk_image_id":           &hcldec.AttrSpec{Name: "boot_disk_image_id", Type: cty.String, Required: false},
 		"project":                      &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
 		"boot_disk_size":               &hcldec.AttrSpec{Name: "boot_disk_size", Type: cty.Number, Required: false},

--- a/component/builder/instance/testdata/instance.pkr.hcl.tmpl
+++ b/component/builder/instance/testdata/instance.pkr.hcl.tmpl
@@ -17,6 +17,9 @@ source "oxide-instance" "test" {
   {{- if .ArtifactName }}
   artifact_name = "{{ .ArtifactName }}"
   {{- end }}
+  {{- if .InsecureSkipVerify }}
+  insecure_skip_verify = true
+  {{- end }}
 
   # To build the image without connecting to it during tests.
   communicator = "none"

--- a/component/data-source/image/config.go
+++ b/component/data-source/image/config.go
@@ -24,6 +24,10 @@ type Config struct {
 	// the `OXIDE_PROFILE` environment variable. Conflicts with `host` and `token`.
 	Profile string `mapstructure:"profile" required:"false"`
 
+	// Skip TLS certificate verification when connecting to the Oxide API.
+	// Defaults to `false`.
+	InsecureSkipVerify bool `mapstructure:"insecure_skip_verify" required:"false"`
+
 	// Name of the image to fetch.
 	Name string `mapstructure:"name" required:"true"`
 

--- a/component/data-source/image/config.hcl2spec.go
+++ b/component/data-source/image/config.hcl2spec.go
@@ -10,11 +10,12 @@ import (
 // FlatConfig is an auto-generated flat version of Config.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatConfig struct {
-	Host    *string `mapstructure:"host" required:"false" cty:"host" hcl:"host"`
-	Token   *string `mapstructure:"token" required:"false" cty:"token" hcl:"token"`
-	Profile *string `mapstructure:"profile" required:"false" cty:"profile" hcl:"profile"`
-	Name    *string `mapstructure:"name" required:"true" cty:"name" hcl:"name"`
-	Project *string `mapstructure:"project" cty:"project" hcl:"project"`
+	Host               *string `mapstructure:"host" required:"false" cty:"host" hcl:"host"`
+	Token              *string `mapstructure:"token" required:"false" cty:"token" hcl:"token"`
+	Profile            *string `mapstructure:"profile" required:"false" cty:"profile" hcl:"profile"`
+	InsecureSkipVerify *bool   `mapstructure:"insecure_skip_verify" required:"false" cty:"insecure_skip_verify" hcl:"insecure_skip_verify"`
+	Name               *string `mapstructure:"name" required:"true" cty:"name" hcl:"name"`
+	Project            *string `mapstructure:"project" cty:"project" hcl:"project"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -29,11 +30,12 @@ func (*Config) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec }
 // The decoded values from this spec will then be applied to a FlatConfig.
 func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"host":    &hcldec.AttrSpec{Name: "host", Type: cty.String, Required: false},
-		"token":   &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
-		"profile": &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
-		"name":    &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
-		"project": &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
+		"host":                 &hcldec.AttrSpec{Name: "host", Type: cty.String, Required: false},
+		"token":                &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
+		"profile":              &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
+		"insecure_skip_verify": &hcldec.AttrSpec{Name: "insecure_skip_verify", Type: cty.Bool, Required: false},
+		"name":                 &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
+		"project":              &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/component/data-source/image/data_source.go
+++ b/component/data-source/image/data_source.go
@@ -71,6 +71,9 @@ func (d *Datasource) Execute() (cty.Value, error) {
 	if d.config.Profile != "" {
 		opts = append(opts, oxide.WithProfile(d.config.Profile))
 	}
+	if d.config.InsecureSkipVerify {
+		opts = append(opts, oxide.WithInsecureSkipVerify())
+	}
 	oxideClient, err := oxide.NewClient(opts...)
 	if err != nil {
 		return cty.NullVal(cty.EmptyObject), fmt.Errorf("failed creating oxide client: %w", err)

--- a/component/data-source/image/data_source_test.go
+++ b/component/data-source/image/data_source_test.go
@@ -116,7 +116,13 @@ func TestAccDataSource_Image(t *testing.T) {
 
 	tmpl := template.Must(template.ParseFS(packerTemplates, "testdata/*.pkr.hcl.tmpl"))
 
-	oxideClient, err := oxide.NewClient()
+	var oxideClientOpts []oxide.ClientOption
+	insecureSkipVerify := os.Getenv("OXIDE_INSECURE_SKIP_VERIFY") == "true"
+	if insecureSkipVerify {
+		oxideClientOpts = append(oxideClientOpts, oxide.WithInsecureSkipVerify())
+	}
+
+	oxideClient, err := oxide.NewClient(oxideClientOpts...)
 	if err != nil {
 		t.Fatalf("failed creating oxide client: %v", err)
 	}
@@ -153,13 +159,15 @@ func TestAccDataSource_Image(t *testing.T) {
 
 			var packerTemplate strings.Builder
 			if err := tmpl.ExecuteTemplate(&packerTemplate, "image.pkr.hcl.tmpl", struct {
-				Name      string
-				Project   string
-				SiloImage bool
+				Name               string
+				Project            string
+				SiloImage          bool
+				InsecureSkipVerify bool
 			}{
-				Name:      imageName,
-				Project:   tc.project,
-				SiloImage: tc.siloImage,
+				Name:               imageName,
+				Project:            tc.project,
+				SiloImage:          tc.siloImage,
+				InsecureSkipVerify: insecureSkipVerify,
 			}); err != nil {
 				t.Fatalf("failed rendering packer template: %v", err)
 			}

--- a/component/data-source/image/testdata/image.pkr.hcl.tmpl
+++ b/component/data-source/image/testdata/image.pkr.hcl.tmpl
@@ -3,6 +3,9 @@ data "oxide-image" "test" {
   {{- if not .SiloImage }}
   project = "{{ .Project }}"
   {{- end }}
+  {{- if .InsecureSkipVerify }}
+  insecure_skip_verify = true
+  {{- end }}
 }
 
 locals {

--- a/docs-partials/component/builder/instance/Config-not-required.mdx
+++ b/docs-partials/component/builder/instance/Config-not-required.mdx
@@ -11,6 +11,9 @@
 - `profile` (string) - Oxide credentials profile. If not specified, this defaults to the value of
   the `OXIDE_PROFILE` environment variable. Conflicts with `host` and `token`.
 
+- `insecure_skip_verify` (bool) - Skip TLS certificate verification when connecting to the Oxide API.
+  Defaults to `false`.
+
 - `boot_disk_size` (uint64) - Size of the boot disk in bytes. Defaults to `21474836480`, or 20 GiB.
 
 - `ip_pool` (string) - IP pool to allocate the instance's external IP from. If not specified, the

--- a/docs-partials/component/data-source/image/Config-not-required.mdx
+++ b/docs-partials/component/data-source/image/Config-not-required.mdx
@@ -11,6 +11,9 @@
 - `profile` (string) - Oxide credentials profile. If not specified, this defaults to the value of
   the `OXIDE_PROFILE` environment variable. Conflicts with `host` and `token`.
 
+- `insecure_skip_verify` (bool) - Skip TLS certificate verification when connecting to the Oxide API.
+  Defaults to `false`.
+
 - `project` (string) - Name or ID of the project containing the image to fetch. Leave blank to fetch
   a silo image instead of a project image.
 


### PR DESCRIPTION
Optionally skip tls verification for both the builder and data source. This flag shouldn't be set in production, but can be useful when working with development instances.

Context: the tls cert on a test rack is often expired. We'll fix that separately, but I wanted to add this flag as well.