### PR TITLE
feat: use go sdk client validation

### DIFF
--- a/component/builder/instance/config.go
+++ b/component/builder/instance/config.go
@@ -10,7 +10,6 @@ package instance
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/hashicorp/packer-plugin-sdk/common"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
@@ -112,18 +111,6 @@ func (c *Config) Prepare(args ...any) ([]string, error) {
 
 	// Set defaults.
 	{
-		if c.Host == "" {
-			c.Host = os.Getenv("OXIDE_HOST")
-		}
-
-		if c.Token == "" {
-			c.Token = os.Getenv("OXIDE_TOKEN")
-		}
-
-		if c.Profile == "" {
-			c.Profile = os.Getenv("OXIDE_PROFILE")
-		}
-
 		if c.Name == "" {
 			name, err := interpolate.Render("packer-{{timestamp}}", nil)
 			if err != nil {
@@ -181,24 +168,6 @@ func (c *Config) Prepare(args ...any) ([]string, error) {
 		}
 
 		c.Comm.SSHTemporaryKeyPairType = "ed25519"
-
-		if c.Profile == "" {
-			if c.Host == "" {
-				multiErr = packer.MultiErrorAppend(multiErr, errors.New("host is required when profile is unset"))
-			}
-
-			if c.Token == "" {
-				multiErr = packer.MultiErrorAppend(multiErr, errors.New("token is required when profile is unset"))
-			}
-		} else {
-			if c.Host != "" {
-				multiErr = packer.MultiErrorAppend(multiErr, errors.New("host cannot be set when profile is set"))
-			}
-
-			if c.Token != "" {
-				multiErr = packer.MultiErrorAppend(multiErr, errors.New("token cannot be set when profile is set"))
-			}
-		}
 
 		if c.Project == "" {
 			multiErr = packer.MultiErrorAppend(multiErr, errors.New("project is required"))

--- a/component/data-source/image/data_source.go
+++ b/component/data-source/image/data_source.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer-plugin-sdk/hcl2helper"
@@ -43,42 +42,9 @@ func (d *Datasource) Configure(args ...any) error {
 		return fmt.Errorf("failed decoding configuration: %w", err)
 	}
 
-	// Set defaults.
-	{
-		if d.config.Host == "" {
-			d.config.Host = os.Getenv("OXIDE_HOST")
-		}
-
-		if d.config.Token == "" {
-			d.config.Token = os.Getenv("OXIDE_TOKEN")
-		}
-
-		if d.config.Profile == "" {
-			d.config.Profile = os.Getenv("OXIDE_PROFILE")
-		}
-	}
-
 	// Enforce required configuration.
 	{
 		var multiErr *packer.MultiError
-
-		if d.config.Profile == "" {
-			if d.config.Host == "" {
-				multiErr = packer.MultiErrorAppend(multiErr, errors.New("host is required when profile is unset"))
-			}
-
-			if d.config.Token == "" {
-				multiErr = packer.MultiErrorAppend(multiErr, errors.New("token is required when profile is unset"))
-			}
-		} else {
-			if d.config.Host != "" {
-				multiErr = packer.MultiErrorAppend(multiErr, errors.New("host cannot be set when profile is set"))
-			}
-
-			if d.config.Token != "" {
-				multiErr = packer.MultiErrorAppend(multiErr, errors.New("token cannot be set when profile is set"))
-			}
-		}
 
 		if d.config.Name == "" {
 			multiErr = packer.MultiErrorAppend(multiErr, errors.New("name is required"))


### PR DESCRIPTION
Removed the configuration validation from this project to use the Go SDK's client validation instead. This way, no matter which plugin uses the Go SDK the client construction provides the same experience.

Relates to SSE-142.