### PR TITLE
misc: correct version to development version

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -264,3 +264,13 @@ successfully built and released.
 than the current tag.
 
 .. Run `make generate` to generate updated documentation.
+
+. Checkout the default branch and push the following changes in a new pull
+request.
+
+.. Update the `main.Version` value in `main.go` to the next development version.
+
+.. Update the `version = ">= X.Y.Z"` version constraint in `docs/README.md`, and
+`example/template.pkr.hcl` to the next development version.
+
+.. Run `make generate` to generate updated documentation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ packer {
   required_plugins {
     oxide = {
       source  = "github.com/oxidecomputer/oxide"
-      version = ">= 0.5.0"
+      version = ">= 0.6.0"
     }
   }
 }

--- a/example/template.pkr.hcl
+++ b/example/template.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     oxide = {
-      version = ">= 0.5.0"
+      version = ">= 0.6.0"
       source  = "github.com/oxidecomputer/oxide"
     }
   }

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 var (
 	// Version is the MAJOR.MINOR.PATCH version of this plugin following semantic
 	// versioning rules. Maintainers must update this as they develop this plugin.
-	Version = "0.5.0"
+	Version = "0.6.0"
 
 	// VersionPreRelease is the pre-release identifier for the version. This is
 	// generally modified via ldflags to create both release and pre-release builds.


### PR DESCRIPTION
The version was not correctly bumped to the next development version. This patch corrects that.