### PR TITLE
feat: configuration option to skip creating image

### DIFF
--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -84,6 +84,12 @@ The configuration arguments for the builder. Arguments can either be required or
   `SOURCE_IMAGE_VERSION-{{timestamp}}` where `SOURCE_IMAGE_VERSION` is the
   version of the source image as retrieved from Oxide.
 
+- `skip_create_image` (bool) - Skip creating the final image. When set to `true`, the build will boot the
+  temporary instance and run all provisioners but will not create a snapshot
+  or image. The temporary instance is still cleaned up normally. This is useful
+  for testing provisioner logic without incurring the cost of image creation.
+  Defaults to `false`.
+
 <!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->
 
 

--- a/component/builder/instance/builder.go
+++ b/component/builder/instance/builder.go
@@ -94,8 +94,8 @@ func (b *Builder) Run(
 		},
 		&commonsteps.StepProvision{},
 		&stepInstanceStop{},
-		&stepSnapshotCreate{},
-		&stepImageCreate{},
+		multistep.If(!b.config.SkipCreateImage, &stepSnapshotCreate{}),
+		multistep.If(!b.config.SkipCreateImage, &stepImageCreate{}),
 	}
 
 	stateBag := &multistep.BasicStateBag{}
@@ -109,6 +109,10 @@ func (b *Builder) Run(
 
 	if err, ok := stateBag.GetOk("error"); ok {
 		return nil, err.(error)
+	}
+
+	if b.config.SkipCreateImage {
+		ui.Say("Skipping image creation since skip_create_image is set.")
 	}
 
 	_, hasImageID := stateBag.GetOk("image_id")

--- a/component/builder/instance/config.go
+++ b/component/builder/instance/config.go
@@ -96,6 +96,13 @@ type Config struct {
 	// version of the source image as retrieved from Oxide.
 	ArtifactVersion string `mapstructure:"artifact_version"`
 
+	// Skip creating the final image. When set to `true`, the build will boot the
+	// temporary instance and run all provisioners but will not create a snapshot
+	// or image. The temporary instance is still cleaned up normally. This is useful
+	// for testing provisioner logic without incurring the cost of image creation.
+	// Defaults to `false`.
+	SkipCreateImage bool `mapstructure:"skip_create_image" required:"false"`
+
 	ctx interpolate.Context
 }
 

--- a/component/builder/instance/config.hcl2spec.go
+++ b/component/builder/instance/config.hcl2spec.go
@@ -85,6 +85,7 @@ type FlatConfig struct {
 	ArtifactName              *string           `mapstructure:"artifact_name" cty:"artifact_name" hcl:"artifact_name"`
 	ArtifactOS                *string           `mapstructure:"artifact_os" cty:"artifact_os" hcl:"artifact_os"`
 	ArtifactVersion           *string           `mapstructure:"artifact_version" cty:"artifact_version" hcl:"artifact_version"`
+	SkipCreateImage           *bool             `mapstructure:"skip_create_image" required:"false" cty:"skip_create_image" hcl:"skip_create_image"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -174,6 +175,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"artifact_name":                &hcldec.AttrSpec{Name: "artifact_name", Type: cty.String, Required: false},
 		"artifact_os":                  &hcldec.AttrSpec{Name: "artifact_os", Type: cty.String, Required: false},
 		"artifact_version":             &hcldec.AttrSpec{Name: "artifact_version", Type: cty.String, Required: false},
+		"skip_create_image":            &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/docs-partials/component/builder/instance/Config-not-required.mdx
+++ b/docs-partials/component/builder/instance/Config-not-required.mdx
@@ -45,4 +45,10 @@
   `SOURCE_IMAGE_VERSION-{{timestamp}}` where `SOURCE_IMAGE_VERSION` is the
   version of the source image as retrieved from Oxide.
 
+- `skip_create_image` (bool) - Skip creating the final image. When set to `true`, the build will boot the
+  temporary instance and run all provisioners but will not create a snapshot
+  or image. The temporary instance is still cleaned up normally. This is useful
+  for testing provisioner logic without incurring the cost of image creation.
+  Defaults to `false`.
+
 <!-- End of code generated from the comments of the Config struct in component/builder/instance/config.go; -->


### PR DESCRIPTION
Added a `skip_image_create` configuration option to skip creating an image artifact. This will still launch the temporary instance and run the provisioners, but will not create a snapshot or image.

Closes SSE-303.