### PR TITLE
feat(builder): dump ssh private key during debug

### DIFF
--- a/component/builder/instance/builder.go
+++ b/component/builder/instance/builder.go
@@ -84,6 +84,12 @@ func (b *Builder) Run(
 			CommConf:            &b.config.Comm,
 			SSHTemporaryKeyPair: b.config.Comm.SSHTemporaryKeyPair,
 		}),
+		multistep.If(b.config.PackerDebug && genTempSSHKeyPair,
+			&communicator.StepDumpSSHKey{
+				Path: fmt.Sprintf("oxide-packer-plugin-%s.pem", b.config.PackerBuildName),
+				SSH:  &b.config.Comm.SSH,
+			},
+		),
 		multistep.If(genTempSSHKeyPair, &stepSSHKeyCreate{}),
 		&stepInstanceCreate{},
 		&stepInstanceExternalIPList{},


### PR DESCRIPTION
When Packer debug mode is enabled and a temporary SSH key pair was generated, this plugin will now dump the SSH private key to a file so that users can SSH into the instance for debugging.

```
> packer build -debug .
Debug mode enabled. Builds will not be parallelized.
oxide-instance.example: output will be in this color.

==> oxide-instance.example: Fetching Oxide image metadata
==> oxide-instance.example: Fetched Oxide image: feb2c8ee-5a1d-4d66-beeb-289b860561bf
==> oxide-instance.example: Pausing after run of step 'stepImageView'. Press enter to continue.
==> oxide-instance.example: Creating temporary ED25519 SSH key for instance...
==> oxide-instance.example: Pausing after run of step 'StepSSHKeyGen'. Press enter to continue.
==> oxide-instance.example: Saving key for debug purposes: oxide-packer-plugin-example.pem
==> oxide-instance.example: Pausing after run of step 'StepDumpSSHKey'. Press enter to continue.
==> oxide-instance.example: Creating Oxide SSH public key
==> oxide-instance.example: Created Oxide SSH public key: 1585fc7b-031b-433d-beb9-70dd41bbb218
==> oxide-instance.example: Pausing after run of step 'stepSSHKeyCreate'. Press enter to continue.
Cancelling build after receiving interrupt
==> oxide-instance.example: Deleting Oxide SSH public key: 1585fc7b-031b-433d-beb9-70dd41bbb218
==> oxide-instance.example: No image_id or image_name. Skipping artifact creation.
Build 'oxide-instance.example' finished after 39 seconds 385 milliseconds.

==> Wait completed after 39 seconds 385 milliseconds
Cleanly cancelled builds after being interrupted.
```

Closes SSE-130.