### PR TITLE
feat(oxide-instance): artifact_description attribute

### DIFF
--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -77,6 +77,9 @@ The configuration arguments for the builder. Arguments can either be required or
   `SOURCE_IMAGE_NAME-{{timestamp}}` where `SOURCE_IMAGE_NAME` is the name of
   the source image as retrieved from Oxide.
 
+- `artifact_description` (string) - Description of the resulting image artifact. Defaults to the description of
+  the source image as retrieved from Oxide.
+
 - `artifact_os` (string) - Operating system of the resulting image artifact. Defaults to the OS of the
   source image as retrieved from Oxide.
 

--- a/component/builder/instance/config.go
+++ b/component/builder/instance/config.go
@@ -87,6 +87,10 @@ type Config struct {
 	// the source image as retrieved from Oxide.
 	ArtifactName string `mapstructure:"artifact_name"`
 
+	// Description of the resulting image artifact. Defaults to the description of
+	// the source image as retrieved from Oxide.
+	ArtifactDescription string `mapstructure:"artifact_description"`
+
 	// Operating system of the resulting image artifact. Defaults to the OS of the
 	// source image as retrieved from Oxide.
 	ArtifactOS string `mapstructure:"artifact_os"`

--- a/component/builder/instance/config.hcl2spec.go
+++ b/component/builder/instance/config.hcl2spec.go
@@ -83,6 +83,7 @@ type FlatConfig struct {
 	Memory                    *uint64           `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	SSHPublicKeys             []string          `mapstructure:"ssh_public_keys" cty:"ssh_public_keys" hcl:"ssh_public_keys"`
 	ArtifactName              *string           `mapstructure:"artifact_name" cty:"artifact_name" hcl:"artifact_name"`
+	ArtifactDescription       *string           `mapstructure:"artifact_description" cty:"artifact_description" hcl:"artifact_description"`
 	ArtifactOS                *string           `mapstructure:"artifact_os" cty:"artifact_os" hcl:"artifact_os"`
 	ArtifactVersion           *string           `mapstructure:"artifact_version" cty:"artifact_version" hcl:"artifact_version"`
 	SkipCreateImage           *bool             `mapstructure:"skip_create_image" required:"false" cty:"skip_create_image" hcl:"skip_create_image"`
@@ -174,6 +175,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"ssh_public_keys":              &hcldec.AttrSpec{Name: "ssh_public_keys", Type: cty.List(cty.String), Required: false},
 		"artifact_name":                &hcldec.AttrSpec{Name: "artifact_name", Type: cty.String, Required: false},
+		"artifact_description":         &hcldec.AttrSpec{Name: "artifact_description", Type: cty.String, Required: false},
 		"artifact_os":                  &hcldec.AttrSpec{Name: "artifact_os", Type: cty.String, Required: false},
 		"artifact_version":             &hcldec.AttrSpec{Name: "artifact_version", Type: cty.String, Required: false},
 		"skip_create_image":            &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},

--- a/component/builder/instance/step_image_create.go
+++ b/component/builder/instance/step_image_create.go
@@ -33,8 +33,8 @@ func (s *stepImageCreate) Run(
 	image, err := oxideClient.ImageCreate(ctx, oxide.ImageCreateParams{
 		Project: oxide.NameOrId(config.Project),
 		Body: &oxide.ImageCreate{
-			Description: "Created by Packer.",
 			Name:        oxide.Name(config.ArtifactName),
+			Description: config.ArtifactDescription,
 			Os:          config.ArtifactOS,
 			Source: oxide.ImageSource{
 				Value: &oxide.ImageSourceSnapshot{

--- a/component/builder/instance/step_image_view.go
+++ b/component/builder/instance/step_image_view.go
@@ -51,6 +51,10 @@ func (s *stepImageView) Run(ctx context.Context, stateBag multistep.StateBag) mu
 		config.ArtifactName = fmt.Sprintf("%s-%s", image.Name, timestamp)
 	}
 
+	if config.ArtifactDescription == "" {
+		config.ArtifactDescription = image.Description
+	}
+
 	if config.ArtifactOS == "" {
 		config.ArtifactOS = image.Os
 	}

--- a/docs-partials/component/builder/instance/Config-not-required.mdx
+++ b/docs-partials/component/builder/instance/Config-not-required.mdx
@@ -38,6 +38,9 @@
   `SOURCE_IMAGE_NAME-{{timestamp}}` where `SOURCE_IMAGE_NAME` is the name of
   the source image as retrieved from Oxide.
 
+- `artifact_description` (string) - Description of the resulting image artifact. Defaults to the description of
+  the source image as retrieved from Oxide.
+
 - `artifact_os` (string) - Operating system of the resulting image artifact. Defaults to the OS of the
   source image as retrieved from Oxide.
 


### PR DESCRIPTION
Added the `artifact_description` attribute to configure the output image's description.

Closes SSE-342.