### PR TITLE
feat: mark the plugin as hcp ready

### DIFF
--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -3,7 +3,7 @@ integration {
   name        = "Oxide"
   description = "The Oxide multi-component plugin can be used with HashiCorp (IBM) Packer to create custom Oxide images."
   identifier  = "packer/oxidecomputer/oxide"
-  flags       = []
+  flags       = ["hcp-ready"]
   docs {
     process_docs    = true
     readme_location = "./README.md"


### PR DESCRIPTION
The Oxide Packer plugin is now marked as HCP ready.

Closes SSE-344.