### PR TITLE
feat(instance): support -force

### DIFF
--- a/component/builder/instance/builder.go
+++ b/component/builder/instance/builder.go
@@ -80,6 +80,7 @@ func (b *Builder) Run(
 
 	steps := []multistep.Step{
 		&stepImageView{},
+		multistep.If(!b.config.SkipCreateImage, &stepArtifactValidate{}),
 		multistep.If(genTempSSHKeyPair, &communicator.StepSSHKeyGen{
 			CommConf:            &b.config.Comm,
 			SSHTemporaryKeyPair: b.config.Comm.SSHTemporaryKeyPair,

--- a/component/builder/instance/step_artifact_validate.go
+++ b/component/builder/instance/step_artifact_validate.go
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package instance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+var _ multistep.Step = (*stepArtifactValidate)(nil)
+
+// stepArtifactValidate is a Packer plugin step to validate whether there's no
+// existing image that will conflict with the specified artifact name.
+type stepArtifactValidate struct{}
+
+// Run validates the artifact name has no conflicts, honoring Packer's `-force`
+// flag to replace an existing image.
+func (s *stepArtifactValidate) Run(
+	ctx context.Context,
+	stateBag multistep.StateBag,
+) multistep.StepAction {
+	oxideClient := stateBag.Get("client").(*oxide.Client)
+	ui := stateBag.Get("ui").(packer.Ui)
+	config := stateBag.Get("config").(*Config)
+
+	ui.Sayf("Validating artifact name: %s", config.ArtifactName)
+
+	image, err := oxideClient.ImageView(ctx, oxide.ImageViewParams{
+		Project: oxide.NameOrId(config.Project),
+		Image:   oxide.NameOrId(config.ArtifactName),
+	})
+	if err != nil {
+		if !errors.Is(err, oxide.ErrObjectNotFound) {
+			ui.Error("Failed validating artifact name.")
+			stateBag.Put("error", err)
+			return multistep.ActionHalt
+		}
+
+		// The artifact name has no conflicts.
+		return multistep.ActionContinue
+	}
+
+	// The artifact name conflicts with an existing image and `-force` was not
+	// set. Bail so the user can decide what to do.
+	if !config.PackerForce {
+		ui.Errorf("Artifact name conflicts with existing image: %s (%s)", image.Name, image.Id)
+		stateBag.Put(
+			"error",
+			fmt.Errorf(
+				"Artifact name conflicts with existing image: %s (%s): use -force to overwrite",
+				config.ArtifactName,
+				image.Id,
+			),
+		)
+	}
+
+	// `-force` was set so we record the existing image information and tell the
+	// user we'll overwrite the existing image later in the build.
+	stateBag.Put("existing_image_id", string(image.Id))
+	stateBag.Put("existing_image_name", string(image.Name))
+
+	ui.Sayf(
+		"Existing image will be overwritten (-force): %s (%s)",
+		image.Name,
+		image.Id,
+	)
+
+	return multistep.ActionContinue
+}
+
+// Cleanup does nothing as [stepArtifactValidate.Run] creates no resources.
+func (s *stepArtifactValidate) Cleanup(stateBag multistep.StateBag) {}

--- a/component/builder/instance/step_image_create.go
+++ b/component/builder/instance/step_image_create.go
@@ -6,6 +6,7 @@ package instance
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
@@ -27,6 +28,28 @@ func (s *stepImageCreate) Run(
 	config := stateBag.Get("config").(*Config)
 
 	snapshotID := stateBag.Get("snapshot_id").(string)
+
+	// `-force` is set so we'll delete the existing image before creating a new one.
+	if config.PackerForce {
+		existingImageID := stateBag.Get("existing_image_id").(string)
+		existingImageName := stateBag.Get("existing_image_name").(string)
+
+		ui.Sayf(
+			"Deleting existing Oxide image %s (%s) because -force is set",
+			existingImageName,
+			existingImageID,
+		)
+
+		err := oxideClient.ImageDelete(ctx, oxide.ImageDeleteParams{
+			Project: oxide.NameOrId(config.Project),
+			Image:   oxide.NameOrId(existingImageName),
+		})
+		if err != nil && !errors.Is(err, oxide.ErrObjectNotFound) {
+			ui.Error("Failed deleting existing Oxide image.")
+			stateBag.Put("error", err)
+			return multistep.ActionHalt
+		}
+	}
 
 	ui.Say("Creating Oxide image")
 


### PR DESCRIPTION
The `oxide-instance` builder now overwrites an existing image artifact when Packer's `-force` flag is set.

Closes SSE-345.