### PR TITLE
fix: do not panic when -force is set and there is no conflicting image

### DIFF
--- a/component/builder/instance/step_image_create.go
+++ b/component/builder/instance/step_image_create.go
@@ -29,10 +29,15 @@ func (s *stepImageCreate) Run(
 
 	snapshotID := stateBag.Get("snapshot_id").(string)
 
-	// `-force` is set so we'll delete the existing image before creating a new one.
-	if config.PackerForce {
-		existingImageID := stateBag.Get("existing_image_id").(string)
-		existingImageName := stateBag.Get("existing_image_name").(string)
+	// `-force` is set so we'll delete the existing image before creating a new
+	// one. The existing image information is only recorded when the artifact
+	// name conflicts with an existing image, so guard against its absence to
+	// avoid panicking on a first build with `-force`.
+	existingImageIDRaw, hasExistingImageID := stateBag.GetOk("existing_image_id")
+	existingImageNameRaw, hasExistingImageName := stateBag.GetOk("existing_image_id")
+	if config.PackerForce && hasExistingImageID && hasExistingImageName {
+		existingImageID := existingImageIDRaw.(string)
+		existingImageName := existingImageNameRaw.(string)
 
 		ui.Sayf(
 			"Deleting existing Oxide image %s (%s) because -force is set",


### PR DESCRIPTION
Builds no longer panic when `-force` is set and the artifact name does not conflict with an existing image.

Resolves SSE-373.