### PR TITLE
fix: error when -force is unset and there is a conflicting image

### DIFF
--- a/component/builder/instance/step_artifact_validate.go
+++ b/component/builder/instance/step_artifact_validate.go
@@ -59,6 +59,7 @@ func (s *stepArtifactValidate) Run(
 				image.Id,
 			),
 		)
+		return multistep.ActionHalt
 	}
 
 	// `-force` was set so we record the existing image information and tell the


### PR DESCRIPTION
Builds now return an error when `-force` is unset and the artifact name conflicts with an existing image.

Resolves SSE-374.