### PR TITLE
fix: only generate ssh keypair when communicator is ssh

### DIFF
--- a/component/builder/instance/builder.go
+++ b/component/builder/instance/builder.go
@@ -73,8 +73,10 @@ func (b *Builder) Run(
 		return nil, fmt.Errorf("failed creating oxide client: %w", err)
 	}
 
-	// Only generate a temporary SSH key pair if the user has not configured SSH.
-	genTempSSHKeyPair := b.config.Comm.SSHPassword == "" &&
+	// Only generate a temporary SSH key pair if the SSH communicator is enabled
+	// and the user has not configured SSH.
+	genTempSSHKeyPair := b.config.Comm.Type == "ssh" &&
+		b.config.Comm.SSHPassword == "" &&
 		b.config.Comm.SSHPrivateKeyFile == "" &&
 		!b.config.Comm.SSHAgentAuth
 


### PR DESCRIPTION
The `oxide-instance` builder now only generates the SSH keypair when the communicator is configured for SSH.

Amp-Thread: https://ampcode.com/threads/T-019f3a8c-7c49-75cb-a834-1768167ee398

Resolves SSE-376.