### PR TITLE
fix(oxide-instance): non-zero exit code in error paths

### DIFF
--- a/component/builder/instance/builder.go
+++ b/component/builder/instance/builder.go
@@ -70,7 +70,8 @@ func (b *Builder) Run(
 	}
 	oxideClient, err := oxide.NewClient(opts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed creating oxide client: %w", err)
+		ui.Error("Failed creating Oxide API client.")
+		return nil, err
 	}
 
 	// Only generate a temporary SSH key pair if the user has not configured SSH.
@@ -120,13 +121,14 @@ func (b *Builder) Run(
 
 	if b.config.SkipCreateImage {
 		ui.Say("Skipping image creation since skip_create_image is set.")
+		return nil, nil
 	}
 
 	_, hasImageID := stateBag.GetOk("image_id")
 	_, hasImageName := stateBag.GetOk("image_name")
 	if !hasImageID || !hasImageName {
-		ui.Say("No image_id or image_name. Skipping artifact creation.")
-		return nil, nil
+		ui.Error("State does not contain image information. Cannot create artifact!")
+		return nil, fmt.Errorf("missing state: image_id, image_name")
 	}
 
 	artifact := &Artifact{

--- a/component/builder/instance/step_instance_create.go
+++ b/component/builder/instance/step_instance_create.go
@@ -140,6 +140,7 @@ func (o *stepInstanceCreate) Run(
 		select {
 		case <-startCtx.Done():
 			ui.Error("Timed out waiting for Oxide instance to start.")
+			stateBag.Put("error", startCtx.Err())
 			return multistep.ActionHalt
 		default:
 		}

--- a/component/builder/instance/step_instance_external_ip_list.go
+++ b/component/builder/instance/step_instance_external_ip_list.go
@@ -6,6 +6,8 @@ package instance
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
@@ -32,6 +34,7 @@ func (s *stepInstanceExternalIPList) Run(
 	instanceIDRaw, ok := stateBag.GetOk("instance_id")
 	if !ok {
 		ui.Error("State does not contain instance ID. Cannot proceed!")
+		stateBag.Put("error", errors.New("missing state: instance_id"))
 		return multistep.ActionHalt
 	}
 	instanceID := instanceIDRaw.(string)
@@ -67,6 +70,7 @@ func (s *stepInstanceExternalIPList) Run(
 		ui.Error(
 			"Instance does not have any valid external IPs. Packer will be unable to connect to this instance.",
 		)
+		stateBag.Put("error", fmt.Errorf("instance does not have any external ips: %s", instanceID))
 		return multistep.ActionHalt
 	}
 

--- a/component/builder/instance/step_instance_stop.go
+++ b/component/builder/instance/step_instance_stop.go
@@ -6,6 +6,7 @@ package instance
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -32,6 +33,7 @@ func (s *stepInstanceStop) Run(
 	instanceIDRaw, ok := stateBag.GetOk("instance_id")
 	if !ok {
 		ui.Error("State does not contain instance ID. Cannot proceed!")
+		stateBag.Put("error", errors.New("missing state: instance_id"))
 		return multistep.ActionHalt
 	}
 	instanceID := instanceIDRaw.(string)
@@ -54,6 +56,7 @@ func (s *stepInstanceStop) Run(
 		select {
 		case <-timeoutCtx.Done():
 			ui.Error("Timed out waiting for Oxide instance to stop.")
+			stateBag.Put("error", timeoutCtx.Err())
 			return multistep.ActionHalt
 		default:
 		}

--- a/component/builder/instance/step_snapshot_create.go
+++ b/component/builder/instance/step_snapshot_create.go
@@ -6,6 +6,7 @@ package instance
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -33,6 +34,7 @@ func (s *stepSnapshotCreate) Run(
 	bootDiskIDRaw, ok := stateBag.GetOk("boot_disk_id")
 	if !ok {
 		ui.Error("State does not contain boot disk ID. Cannot proceed!")
+		stateBag.Put("error", errors.New("missing state: boot_disk_id"))
 		return multistep.ActionHalt
 	}
 	bootDiskID := bootDiskIDRaw.(string)


### PR DESCRIPTION
The `oxide-instance` builder now exits with a non-zero exit code in error paths.

Resolves SSE-375.