### PR TITLE
fix: interpolate the configuration to support json templates

### DIFF
--- a/component/builder/instance/config.go
+++ b/component/builder/instance/config.go
@@ -132,7 +132,7 @@ func (c *Config) Prepare(args ...any) ([]string, error) {
 
 	if err := config.Decode(c, &config.DecodeOpts{
 		Metadata:    &metadata,
-		Interpolate: false,
+		Interpolate: true,
 		PluginType:  BuilderID,
 	}, args...); err != nil {
 		return nil, fmt.Errorf("failed decoding configuration: %w", err)

--- a/component/data-source/image/data_source.go
+++ b/component/data-source/image/data_source.go
@@ -38,7 +38,7 @@ func (d *Datasource) ConfigSpec() hcldec.ObjectSpec {
 // to use during execution.
 func (d *Datasource) Configure(args ...any) error {
 	if err := config.Decode(&d.config, &config.DecodeOpts{
-		Interpolate: false,
+		Interpolate: true,
 	}, args...); err != nil {
 		return fmt.Errorf("failed decoding configuration: %w", err)
 	}


### PR DESCRIPTION
Turned configuration interpolation back on to support legacy JSON templates, like our Oxide template in
https://github.com/kubernetes-sigs/image-builder.

Relates to SSE-343.